### PR TITLE
✨ feat: set up socket and aws cloudwatch to send building logs to client

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "lint": "eslint --ext .ts src/"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.209.0",
     "@aws-sdk/client-ec2": "^3.204.0",
     "@aws-sdk/client-route-53": "^3.206.0",
     "@aws-sdk/client-s3": "^3.199.0",
     "axios": "^1.1.3",
+    "chalk": "4.1.2",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "^4.3.4",
@@ -29,6 +31,7 @@
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.6.5",
     "morgan": "^1.10.0",
+    "socket.io": "^4.5.3",
     "winston": "^3.8.2"
   },
   "devDependencies": {

--- a/src/api/controllers/deployUserRepo.ts
+++ b/src/api/controllers/deployUserRepo.ts
@@ -2,6 +2,7 @@ import createError from "http-errors";
 
 import catchAsync from "../../utils/asyncHandler";
 
+import { bulidingLogSocket } from "../../deploy/socket";
 import createDeployment from "../../deploy/build-utils/createDeployment";
 
 export const deployUserRepo = catchAsync(async (req, res, next) => {
@@ -34,6 +35,8 @@ export const deployUserRepo = catchAsync(async (req, res, next) => {
   };
 
   const newDeploymentInfo = await createDeployment(repoBuildOptions);
+
+  bulidingLogSocket();
 
   return res.json({
     result: "ok",

--- a/src/api/github/oauth.ts
+++ b/src/api/github/oauth.ts
@@ -19,7 +19,7 @@ const GithubOauth = axios.create({
 export const getGithubToken = async (code: string) => {
   const { data } = await GithubOauth.post<GithubToken>(
     "/login/oauth/access_token?",
-    null,
+    {},
     {
       params: {
         client_id: Config.CLIENT_ID,

--- a/src/bin/www.ts
+++ b/src/bin/www.ts
@@ -4,6 +4,7 @@
 import Debug from "debug";
 import http from "http";
 import { AddressInfo } from "net";
+import SocketSingleton from "../deploy/socket";
 
 import app from "../app";
 import Logger from "../loaders/logger";
@@ -22,6 +23,7 @@ app.set("port", port);
  */
 
 const server = http.createServer(app);
+export const socketIO = new SocketSingleton(server);
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,8 @@ dotenv.config();
 const Config = {
   DATABASE_URL: process.env.MONGODB_URI,
   JWT_SECRET: process.env.JWT_SECRET_KEY,
+  SERVER_URL: process.env.ORIGIN_SERVER_URL,
+  CLIENT_URL: process.env.CLIENT_URL,
   CLIENT_ID: process.env.GITHUB_CLIENT_ID,
   CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   USER_CREDENTIAL_ID: process.env.GITHUB_USER_CREDENTIAL_ID,
@@ -19,6 +21,15 @@ const Config = {
   HOSTED_ZONE_ID: process.env.AWS_HOSTED_ZONE_ID,
   NODEJS_FERMIUM: "14.21.0",
   NODEJS_GALLIUM: "16.18.0",
+  CLIENT_OPTIONS: {
+    debug: true,
+  },
+  LOG_FILTERS: {
+    verbose: " ",
+    userDataFilter: "-epel -HTTP -fedora -Length",
+    cloudInitFilter:
+      "?cloud ?init -systemd -kernel -rsyslogd -journal -augenrules -rngd -acpid -chronyd -ec2net -auditd -audispd -dhclient -hibinit -network -ssm -cloudwatch -SHA256 -SSH -info",
+  },
 };
 
 export default Config;

--- a/src/deploy/aws/config/cloudwatch-agent-config.json
+++ b/src/deploy/aws/config/cloudwatch-agent-config.json
@@ -1,0 +1,102 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/user-data.log",
+            "log_group_name": "user-data.log",
+            "log_stream_name": "{instance_id}",
+            "retention_in_days": -1
+          },
+          {
+            "file_path": "/var/log/cloud-init.log",
+            "log_group_name": "cloud-init.log",
+            "log_stream_name": "{instance_id}",
+            "retention_in_days": -1
+          },
+          {
+            "file_path": "/var/log/cloud-init-output.log",
+            "log_group_name": "cloud-init-output.log",
+            "log_stream_name": "{instance_id}",
+            "retention_in_days": -1
+          },
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "messages",
+            "log_stream_name": "{instance_id}",
+            "retention_in_days": -1
+          },
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "syslog",
+            "log_stream_name": "{instance_id}",
+            "retention_in_days": -1
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "aggregation_dimensions": [["InstanceId"]],
+    "append_dimensions": {
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "metrics_collected": {
+      "collectd": {
+        "metrics_aggregation_interval": 60
+      },
+      "cpu": {
+        "measurement": [
+          "cpu_usage_idle",
+          "cpu_usage_iowait",
+          "cpu_usage_user",
+          "cpu_usage_system"
+        ],
+        "metrics_collection_interval": 60,
+        "resources": ["*"],
+        "totalcpu": false
+      },
+      "disk": {
+        "measurement": ["used_percent", "inodes_free"],
+        "metrics_collection_interval": 60,
+        "resources": ["*"]
+      },
+      "diskio": {
+        "measurement": [
+          "io_time",
+          "write_bytes",
+          "read_bytes",
+          "writes",
+          "reads"
+        ],
+        "metrics_collection_interval": 60,
+        "resources": ["*"]
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 60
+      },
+      "netstat": {
+        "measurement": ["tcp_established", "tcp_time_wait"],
+        "metrics_collection_interval": 60
+      },
+      "statsd": {
+        "metrics_aggregation_interval": 60,
+        "metrics_collection_interval": 30,
+        "service_address": ":8125"
+      },
+      "swap": {
+        "measurement": ["swap_used_percent"],
+        "metrics_collection_interval": 60
+      }
+    }
+  }
+}

--- a/src/deploy/aws/cwl_describelogstreams.ts
+++ b/src/deploy/aws/cwl_describelogstreams.ts
@@ -1,0 +1,41 @@
+import {
+  DescribeLogStreamsCommand,
+  LogStream,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import Config from "../../config";
+import cwlClient from "./libs/cloudWatchLogsClient";
+
+import { DeploymentError } from "../../utils/errors";
+import { createDeploymentDebug } from "../../utils/createDebug";
+
+const describeLogStreams = async (instanceId: string) => {
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+
+  const logStreamsParams = {
+    logGroupName: "user-data.log",
+    logStreamNamePrefix: instanceId,
+  };
+
+  try {
+    const command = new DescribeLogStreamsCommand(logStreamsParams);
+
+    const data = await cwlClient.send(command);
+
+    if (data.logStreams) {
+      const logStream: LogStream = data.logStreams[0];
+
+      return logStream;
+    }
+  } catch (err) {
+    debug(
+      `Error: An unexpected error occurred during DescribeLogStreamsCommand - ${err}`,
+    );
+    throw new DeploymentError({
+      code: "cloudWatchLogsClient_DescribeLogStreamsCommand",
+      message: "DescribeLogStreamsCommand didn't work as expected",
+    });
+  }
+};
+
+export default describeLogStreams;

--- a/src/deploy/aws/cwl_filterlogeventscommand.ts
+++ b/src/deploy/aws/cwl_filterlogeventscommand.ts
@@ -1,0 +1,68 @@
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+
+import Config from "../../config";
+import cwlClient from "./libs/cloudWatchLogsClient";
+
+import { DeploymentError } from "../../utils/errors";
+import {
+  createDeploymentDebug,
+  createBuildingLogDebug,
+} from "../../utils/createDebug";
+
+const getFilteredLogEvents = async (instanceId: string, subdomain: string) => {
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+  const debugBuildingLog = createBuildingLogDebug(Config.CLIENT_OPTIONS.debug);
+
+  debug(
+    `Requesting a building log of newly created deployment - ${subdomain}.${Config.SERVER_URL}...`,
+  );
+
+  const filterLogEventsParams = {
+    logGroupName: "user-data.log",
+    logStreamNames: [instanceId],
+    filterPattern: Config.LOG_FILTERS.userDataFilter,
+  };
+
+  try {
+    const command = new FilterLogEventsCommand(filterLogEventsParams);
+
+    const data = await cwlClient.send(command);
+
+    if (data.events) {
+      const filteredLogEvent = data.events;
+
+      debug(
+        "Sending back to client of the newly created deployment buliding log...",
+      );
+
+      const filteredLogEventMessages = filteredLogEvent.map(log => {
+        const ipSimpleRegex = / ip-\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}/;
+        const filteredMessage = log.message?.replace(ipSimpleRegex, "");
+
+        return filteredMessage;
+      });
+
+      filteredLogEventMessages.forEach((bulidingLog, i) =>
+        setTimeout(() => {
+          debugBuildingLog(bulidingLog as string);
+        }, i * 100),
+      );
+
+      debug(
+        `A building log of newly created deployment - ${subdomain}.${Config.SERVER_URL} has been requested`,
+      );
+
+      return filteredLogEventMessages;
+    }
+  } catch (err) {
+    debug(
+      `Error: An unexpected error occurred during FilterLogEventsCommand - ${err}`,
+    );
+    throw new DeploymentError({
+      code: "cwlClient_FilterLogEventsCommand",
+      message: "FilterLogEventsCommand didn't work as expected",
+    });
+  }
+};
+
+export default getFilteredLogEvents;

--- a/src/deploy/aws/ec2_createinstances.ts
+++ b/src/deploy/aws/ec2_createinstances.ts
@@ -7,7 +7,7 @@ import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";
 
 const createInstance = async (commands: string[]) => {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   const instanceParams = {
     ImageId: Config.AMI_ID,

--- a/src/deploy/aws/ec2_createinstances.ts
+++ b/src/deploy/aws/ec2_createinstances.ts
@@ -23,6 +23,7 @@ const createInstance = async (commands: string[]) => {
 
   try {
     const command = new RunInstancesCommand(instanceParams);
+
     const data = await ec2Client.send(command);
 
     if (data.Instances) {

--- a/src/deploy/aws/ec2_describeinstances.ts
+++ b/src/deploy/aws/ec2_describeinstances.ts
@@ -1,12 +1,13 @@
 import { DescribeInstancesCommand } from "@aws-sdk/client-ec2";
 
+import Config from "../../config";
 import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";
 
 import ec2Client from "./libs/ec2Client";
 
 const describeInstanceIp = async (instanceId: string) => {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   try {
     const command = new DescribeInstancesCommand({ InstanceIds: [instanceId] });

--- a/src/deploy/aws/ec2_describeinstances.ts
+++ b/src/deploy/aws/ec2_describeinstances.ts
@@ -1,16 +1,19 @@
 import { DescribeInstancesCommand } from "@aws-sdk/client-ec2";
 
 import Config from "../../config";
+import ec2Client from "./libs/ec2Client";
+
 import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";
-
-import ec2Client from "./libs/ec2Client";
 
 const describeInstanceIp = async (instanceId: string) => {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
+  const instancesParams = { InstanceIds: [instanceId] };
+
   try {
-    const command = new DescribeInstancesCommand({ InstanceIds: [instanceId] });
+    const command = new DescribeInstancesCommand(instancesParams);
+
     const data = await ec2Client.send(command);
 
     let publicIpAddress;

--- a/src/deploy/aws/libs/cloudWatchLogsClient.ts
+++ b/src/deploy/aws/libs/cloudWatchLogsClient.ts
@@ -1,0 +1,9 @@
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
+
+import Config from "../../../config";
+
+const REGION = Config.INSTANCE_REGION;
+
+const cwlClient = new CloudWatchLogsClient({ region: REGION });
+
+export default cwlClient;

--- a/src/deploy/aws/route53_createrecord.ts
+++ b/src/deploy/aws/route53_createrecord.ts
@@ -16,7 +16,7 @@ const createDNSRecord = async ({
   recordValue,
   recordType = RRType.A,
 }: CreateDNSRecordProps) => {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   const recordName = `${subdomain}.jaamtoast.click`;
 

--- a/src/deploy/aws/route53_createrecord.ts
+++ b/src/deploy/aws/route53_createrecord.ts
@@ -9,7 +9,7 @@ import route53Client from "./libs/route53Client";
 import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";
 
-import { CreateDNSRecordProps, RecordSetResponse } from "../../types/custom";
+import { CreateDNSRecordProps } from "../../types/custom";
 
 const createDNSRecord = async ({
   subdomain,
@@ -40,6 +40,7 @@ const createDNSRecord = async ({
 
   try {
     const command = new ChangeResourceRecordSetsCommand(recordParams);
+
     const data = await route53Client.send(command);
 
     if (data.ChangeInfo) {

--- a/src/deploy/aws/route53_createrecord.ts
+++ b/src/deploy/aws/route53_createrecord.ts
@@ -18,7 +18,7 @@ const createDNSRecord = async ({
 }: CreateDNSRecordProps) => {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
-  const recordName = `${subdomain}.jaamtoast.click`;
+  const recordName = `${subdomain}.${Config.SERVER_URL}`;
 
   const recordParams = {
     HostedZoneId: Config.HOSTED_ZONE_ID,

--- a/src/deploy/aws/route53_describerecord.ts
+++ b/src/deploy/aws/route53_describerecord.ts
@@ -1,16 +1,18 @@
 import { GetChangeCommand } from "@aws-sdk/client-route-53";
 
 import Config from "../../config";
+import route53Client from "./libs/route53Client";
+
 import { createDeploymentDebug } from "../../utils/createDebug";
 import { DeploymentError } from "../../utils/errors";
-
-import route53Client from "./libs/route53Client";
 
 const describeRecord = async (Id: string) => {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
+  const getChangeParams = { Id };
+
   try {
-    const command = new GetChangeCommand({ Id });
+    const command = new GetChangeCommand(getChangeParams);
 
     const data = await route53Client.send(command);
 

--- a/src/deploy/aws/route53_describerecord.ts
+++ b/src/deploy/aws/route53_describerecord.ts
@@ -1,12 +1,13 @@
 import { GetChangeCommand } from "@aws-sdk/client-route-53";
 
+import Config from "../../config";
 import { createDeploymentDebug } from "../../utils/createDebug";
 import { DeploymentError } from "../../utils/errors";
 
 import route53Client from "./libs/route53Client";
 
 const describeRecord = async (Id: string) => {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   try {
     const command = new GetChangeCommand({ Id });

--- a/src/deploy/build-utils/buildDeploymentCommands.ts
+++ b/src/deploy/build-utils/buildDeploymentCommands.ts
@@ -41,7 +41,7 @@ export default function buildDeploymentCommands(
 
   const nvmInstall = [
     `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash`,
-    `. /root/.nvm/nvm.sh`,
+    `source /root/.nvm/nvm.sh`,
     `nvm install ${NODE_VERSION}`,
   ];
 
@@ -101,6 +101,7 @@ export default function buildDeploymentCommands(
     `pm2 start npm --name "next" -- start`,
     `pm2 save`,
     `pm2 startup`,
+    `sudo env PATH=$PATH:/home/ec2-user/.nvm/versions/node/v16.18.0/bin /home/ec2-user/.config/yarn/global/node_modules/pm2/bin/pm2 startup systemd -u ec2-user --hp /home/ec2-user`,
   ];
 
   const commands = [

--- a/src/deploy/build-utils/buildDeploymentCommands.ts
+++ b/src/deploy/build-utils/buildDeploymentCommands.ts
@@ -20,10 +20,10 @@ export default function buildDeploymentCommands(
   const NODE_VERSION = nodeVersion.includes("14")
     ? Config.NODEJS_FERMIUM
     : Config.NODEJS_GALLIUM;
-  const CUSTOM_DOMAIN = `${REPO_NAME}.jaamtoast.click`;
+  const CUSTOM_DOMAIN = `${REPO_NAME}.${Config.SERVER_URL}`;
 
   debug(
-    `GIT_CLONE_URL: ${remoteUrl}, REPO_NAME: ${repoName}, NODE_VERSION: ${NODE_VERSION}, CUSTOM_DOMAIN: ${REPO_NAME}.jaamtoast.click`,
+    `GIT_CLONE_URL: ${remoteUrl}, REPO_NAME: ${repoName}, NODE_VERSION: ${NODE_VERSION}, CUSTOM_DOMAIN: ${REPO_NAME}.${Config.SERVER_URL}`,
   );
 
   const yumUpdate = [

--- a/src/deploy/build-utils/buildDeploymentCommands.ts
+++ b/src/deploy/build-utils/buildDeploymentCommands.ts
@@ -7,7 +7,7 @@ export default function buildDeploymentCommands(
   clientOptions: ClientOptions,
   deploymentOptions: DeploymentOptions = { nodeVersion: "16.x" },
 ) {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   const { remoteUrl, repoName } = clientOptions;
   const { nodeVersion, envList } = deploymentOptions;

--- a/src/deploy/build-utils/buildDeploymentCommands.ts
+++ b/src/deploy/build-utils/buildDeploymentCommands.ts
@@ -26,7 +26,18 @@ export default function buildDeploymentCommands(
     `GIT_CLONE_URL: ${remoteUrl}, REPO_NAME: ${repoName}, NODE_VERSION: ${NODE_VERSION}, CUSTOM_DOMAIN: ${REPO_NAME}.jaamtoast.click`,
   );
 
-  const yumUpdate = [`#!/usr/bin/bash`, `yum update -y`];
+  const yumUpdate = [
+    `#!/usr/bin/bash`,
+    `yum update -y`,
+    `exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1`,
+  ];
+
+  const cloudWatchAgent = [
+    `yum install amazon-cloudwatch-agent`,
+    `yum install -y collectd`,
+    `cd /opt/aws/amazon-cloudwatch-agent/bin`,
+    `/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:config.json`,
+  ];
 
   const nvmInstall = [
     `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash`,
@@ -94,6 +105,7 @@ export default function buildDeploymentCommands(
 
   const commands = [
     ...yumUpdate,
+    ...cloudWatchAgent,
     ...nvmInstall,
     ...gitClone,
     ...setEnv,

--- a/src/deploy/build-utils/createDeployment.ts
+++ b/src/deploy/build-utils/createDeployment.ts
@@ -5,6 +5,7 @@ import describeInstanceIp from "../aws/ec2_describeinstances";
 import buildDeploymentCommands from "./buildDeploymentCommands";
 import createDNSRecord from "../aws/route53_createrecord";
 import runCertbot from "./runCertbot";
+import runGetFilteredLogEvents from "./runGetFilteredLogEvents";
 
 import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";

--- a/src/deploy/build-utils/createDeployment.ts
+++ b/src/deploy/build-utils/createDeployment.ts
@@ -1,3 +1,5 @@
+import Config from "../../config";
+
 import createInstance from "../aws/ec2_createinstances";
 import describeInstanceIp from "../aws/ec2_describeinstances";
 import buildDeploymentCommands from "./buildDeploymentCommands";
@@ -13,7 +15,7 @@ import { RepoBuildOptions } from "../../types/custom";
 export default async function createDeployment(
   repoBuildOptions: RepoBuildOptions,
 ) {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   debug("Creating deployment...", "Creating build commands...");
 
@@ -76,6 +78,10 @@ export default async function createDeployment(
               recordChangeInfo.recordId,
               instanceId as string,
               repoName,
+            );
+
+            debug(
+              `Waiting for requesting a certificate to enable HTTPS on ${repoName}.${Config.SERVER_URL}...`,
             );
 
             runGetFilteredLogEvents(instanceId as string, repoName);

--- a/src/deploy/build-utils/createDeployment.ts
+++ b/src/deploy/build-utils/createDeployment.ts
@@ -91,7 +91,7 @@ export default async function createDeployment(
             );
 
             const newDeploymentInfo = {
-              deployedUrl: `${repoName}.jaamtoast.click`,
+              deployedUrl: `${repoName}.${Config.SERVER_URL}`,
               deployPublicAddress: publicIpAddress,
               deployRepoName: repoName,
               deployRemoteUrl: remoteUrl,

--- a/src/deploy/build-utils/createDeployment.ts
+++ b/src/deploy/build-utils/createDeployment.ts
@@ -78,7 +78,11 @@ export default async function createDeployment(
               repoName,
             );
 
-            debug("Sending back to client of newly created deployment info...");
+            runGetFilteredLogEvents(instanceId as string, repoName);
+
+            debug(
+              `Waiting for a building log of  ${repoName}.${Config.SERVER_URL}...`,
+            );
 
             const newDeploymentInfo = {
               deployedUrl: `${repoName}.jaamtoast.click`,

--- a/src/deploy/build-utils/runCertbot.ts
+++ b/src/deploy/build-utils/runCertbot.ts
@@ -31,6 +31,10 @@ export default function runCertbot(
         `Checking instanceState - [${instanceState}]`,
       );
 
+      debug(
+        `Still waiting for requesting a certificate to enable HTTPS on ${subdomain}.${Config.SERVER_URL}...`,
+      );
+
       if (
         recordStatus === "INSYNC" &&
         instanceState === InstanceStateName.running

--- a/src/deploy/build-utils/runCertbot.ts
+++ b/src/deploy/build-utils/runCertbot.ts
@@ -1,11 +1,12 @@
 import { InstanceStateName } from "@aws-sdk/client-ec2";
-import { createDeploymentDebug } from "../../utils/createDebug";
-import { DeploymentError } from "../../utils/errors";
 
 import Config from "../../config";
 import describeInstanceIp from "../aws/ec2_describeinstances";
 import describeRecord from "../aws/route53_describerecord";
-import runCertbotCommand from "../cli/runCertbotCommands";
+import runCertbotCommands from "../cli/runCertbotCommands";
+
+import { createDeploymentDebug } from "../../utils/createDebug";
+import { DeploymentError } from "../../utils/errors";
 
 export default function runCertbot(
   recordId: string,
@@ -14,7 +15,7 @@ export default function runCertbot(
 ) {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
-  const recordStatusInterval = setInterval(getRecordStatus, 1000);
+  const recordStatusInterval = setInterval(getRecordStatus, 2000);
 
   async function getRecordStatus() {
     let recordStatus;
@@ -41,7 +42,7 @@ export default function runCertbot(
       ) {
         clearInterval(recordStatusInterval);
 
-        setTimeout(() => runCertbotCommand(instanceId, subdomain), 120000);
+        setTimeout(() => runCertbotCommands(instanceId, subdomain), 120000);
 
         return recordStatus;
       }

--- a/src/deploy/build-utils/runCertbot.ts
+++ b/src/deploy/build-utils/runCertbot.ts
@@ -2,6 +2,7 @@ import { InstanceStateName } from "@aws-sdk/client-ec2";
 import { createDeploymentDebug } from "../../utils/createDebug";
 import { DeploymentError } from "../../utils/errors";
 
+import Config from "../../config";
 import describeInstanceIp from "../aws/ec2_describeinstances";
 import describeRecord from "../aws/route53_describerecord";
 import runCertbotCommand from "../cli/runCertbotCommands";
@@ -11,7 +12,7 @@ export default function runCertbot(
   instanceId: string,
   subdomain: string,
 ) {
-  const debug = createDeploymentDebug(true);
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   const recordStatusInterval = setInterval(getRecordStatus, 1000);
 

--- a/src/deploy/build-utils/runGetFilteredLogEvents.ts
+++ b/src/deploy/build-utils/runGetFilteredLogEvents.ts
@@ -1,0 +1,49 @@
+import Config from "../../config";
+
+import describeLogStreams from "../aws/cwl_describelogstreams";
+import getFilteredLogEvents from "../aws/cwl_filterlogeventscommand";
+
+import { createDeploymentDebug } from "../../utils/createDebug";
+import { DeploymentError } from "../../utils/errors";
+
+export default function runGetFilteredLogEvents(
+  instanceId: string,
+  subdomain: string,
+) {
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+
+  const logStreamStatusInterval = setInterval(getLogStreamStatus, 2000);
+
+  async function getLogStreamStatus() {
+    let logStreamStatus;
+
+    try {
+      logStreamStatus = await describeLogStreams(instanceId);
+
+      debug(`Checking logStreamStatus - [${logStreamStatus?.logStreamName}]`);
+
+      debug(
+        `Still waiting for requesting a log stream on ${subdomain}.${Config.SERVER_URL}...`,
+      );
+
+      if (logStreamStatus?.logStreamName === instanceId) {
+        clearInterval(logStreamStatusInterval);
+
+        const filteredLogEventMessages = setTimeout(
+          () => getFilteredLogEvents(instanceId, subdomain),
+          70000,
+        );
+
+        return filteredLogEventMessages;
+      }
+    } catch (err) {
+      debug(
+        `Error: An unexpected error occurred during DescribeLogStreamsCommand - ${err}`,
+      );
+      throw new DeploymentError({
+        code: "cloudWatchLogsClient_DescribeLogStreamsCommand",
+        message: "logStreamStatus.logStreamName is typeof undefined",
+      });
+    }
+  }
+}

--- a/src/deploy/cli/runCertbotCommands.ts
+++ b/src/deploy/cli/runCertbotCommands.ts
@@ -1,10 +1,12 @@
 import { spawn } from "child_process";
 
+import Config from "../../config";
+
 import { DeploymentError } from "../../utils/errors";
 import { createCertbotDebug } from "../../utils/createDebug";
 
 async function runCertbotCommands(instanceId: string, subdomain: string) {
-  const debug = createCertbotDebug(true);
+  const debug = createCertbotDebug(Config.CLIENT_OPTIONS.debug);
 
   const controller = new AbortController();
   const { signal } = controller;

--- a/src/deploy/cli/runCertbotCommands.ts
+++ b/src/deploy/cli/runCertbotCommands.ts
@@ -13,7 +13,7 @@ async function runCertbotCommands(instanceId: string, subdomain: string) {
 
   debug(
     `letsencrypt - Plugins selected: Authenticator nginx, Installer nginx`,
-    `Requesting a certificate to enable HTTPS on ${subdomain}.jaamtoast.click `,
+    `Requesting a certificate to enable HTTPS on ${subdomain}.${Config.SERVER_URL}`,
   );
 
   try {
@@ -27,7 +27,7 @@ async function runCertbotCommands(instanceId: string, subdomain: string) {
         "--targets",
         `[{"Key":"InstanceIds","Values":["${instanceId}"]}]`,
         "--parameters",
-        `{"commands":["#!/bin/bash","yum -y update",". /root/.nvm/nvm.sh","cd /home/ec2-user","certbot --nginx --non-interactive --agree-tos -d ${subdomain}.jaamtoast.click -m taewan.seoul@gmail.com","cd /etc","echo 39      1,13    *       *       *       root    certbot renew --no-self-upgrade >> crontab","systemctl restart crond","service nginx restart"]}`,
+        `{"commands":["#!/bin/bash","yum -y update","source /root/.nvm/nvm.sh","cd /home/ec2-user","certbot --nginx --non-interactive --agree-tos -d ${subdomain}.${Config.SERVER_URL} -m taewan.seoul@gmail.com","cd /etc","echo 39      1,13    *       *       *       root    certbot renew --no-self-upgrade >> crontab","systemctl restart crond","service nginx restart"]}`,
       ],
       { signal },
     );
@@ -68,7 +68,7 @@ async function runCertbotCommands(instanceId: string, subdomain: string) {
   } catch (err) {
     controller.abort();
     debug(
-      `Error: An unexpected error occurred requesting a certificate for ${subdomain}.jaamtoast.click - ${err}`,
+      `Error: An unexpected error occurred requesting a certificate for ${subdomain}.${Config.SERVER_URL} - ${err}`,
     );
     throw new DeploymentError({
       code: "letsencrypt_certbot",

--- a/src/deploy/socket/bulidingLogSocket.ts
+++ b/src/deploy/socket/bulidingLogSocket.ts
@@ -1,0 +1,47 @@
+import * as fs from "fs";
+import { Socket } from "socket.io";
+
+import Config from "../../config";
+import { socketIO } from "../../bin/www";
+
+import { DeploymentError } from "../../utils/errors";
+import { createDeploymentDebug } from "../../utils/createDebug";
+
+export default async function bulidingLogSocket() {
+  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+
+  const io = socketIO.getInstance();
+
+  io.on("connection", (socket: Socket) => {
+    socket.on("connection", () => {
+      debug(
+        "Socket is connected in order to send back to client the newly created deployment buliding log",
+      );
+    });
+
+    socket.on("get-building-log", repoName => {
+      `Getting ready for sending a buliding log for ${repoName}`;
+    });
+
+    let prevData: string;
+
+    fs.watch("logs/bulidtime.log", (eventType, fileName) => {
+      fs.readFile(`logs/${fileName}`, "utf8", (err, data) => {
+        if (err) {
+          throw new DeploymentError({
+            code: "socketBulidtimeLog",
+            message: `Error: An unexpected error occurred during socketBulidtimeLog - ${err}`,
+          });
+        }
+
+        if (prevData === data) {
+          return () => {};
+        }
+
+        prevData = data;
+
+        socket.emit("new-building-log", data);
+      });
+    });
+  });
+}

--- a/src/deploy/socket/index.ts
+++ b/src/deploy/socket/index.ts
@@ -1,0 +1,6 @@
+import SocketSingleton from "./socketSingleton";
+import bulidingLogSocket from "./bulidingLogSocket";
+
+export { bulidingLogSocket };
+
+export default SocketSingleton;

--- a/src/deploy/socket/socketSingleton.ts
+++ b/src/deploy/socket/socketSingleton.ts
@@ -1,0 +1,38 @@
+import { Server } from "http";
+import { Server as socketServer } from "socket.io";
+
+import { DefaultEventsMap } from "socket.io/dist/typed-events";
+
+import Config from "../../config";
+
+class SocketSingleton extends socketServer {
+  private static instance: socketServer<
+    DefaultEventsMap,
+    DefaultEventsMap,
+    DefaultEventsMap,
+    any
+  > | null = null;
+
+  constructor(server: Server) {
+    super();
+
+    if (SocketSingleton.instance) {
+      throw new Error("You can only create one instance!");
+    }
+
+    SocketSingleton.instance = new socketServer(server, {
+      cors: {
+        origin: Config.CLIENT_URL,
+        methods: ["GET", "POST"],
+      },
+    });
+
+    process.stderr.write("A new socket instance is created");
+  }
+
+  getInstance() {
+    return SocketSingleton.instance as socketServer;
+  }
+}
+
+export default SocketSingleton;

--- a/src/utils/createDebug.ts
+++ b/src/utils/createDebug.ts
@@ -1,11 +1,40 @@
-export function createDeploymentDebug(debug?: boolean) {
+import * as fs from "fs";
+
+import chalk from "chalk";
+
+export function createDeploymentDebug(debug: boolean) {
   if (debug) {
     return (...logs: string[]) => {
+      const dayTime = new Date().toISOString();
+      const formattedTime = `${dayTime.split("T")[0]} ${
+        dayTime.split("T")[1].split(".")[0]
+      }`;
+
       process.stderr.write(
-        [`[deployment-debug]`, ...logs, `${new Date().toISOString()}`].join(
-          " ",
-        ) + "\n",
+        [
+          chalk.cyanBright.bold("[deployment-debug]"),
+          chalk.blackBright(`${formattedTime}`),
+          ...logs,
+        ].join(" ") + "\n",
       );
+
+      fs.open("logs/bulidtime.log", "w", (err, fd) => {
+        if (err) throw Error(err.message);
+
+        logs.forEach(log => {
+          // process.stderr.write(log + " " + "\n");
+
+          fs.write(
+            fd,
+            `${chalk.cyanBright.bold(
+              "[jaamtoast-deployment]",
+            )} ${chalk.blackBright(`${formattedTime}`)} ${log}` + "\n",
+            err => {
+              if (err) throw Error(err.message);
+            },
+          );
+        });
+      });
     };
   }
 
@@ -15,10 +44,75 @@ export function createDeploymentDebug(debug?: boolean) {
 export function createCertbotDebug(debug?: boolean) {
   if (debug) {
     return (...logs: string[]) => {
+      const dayTime = new Date().toISOString();
+      const formattedTime = `${dayTime.split("T")[0]} ${
+        dayTime.split("T")[1].split(".")[0]
+      }`;
+
       process.stderr.write(
-        [`[cerbot-debug] ${new Date().toISOString()}`, ...logs].join(" ") +
-          "\n",
+        [
+          chalk.yellowBright.bold("[certbot-debug]"),
+          chalk.blackBright(`${formattedTime}`),
+          ...logs,
+        ].join(" ") + "\n",
       );
+
+      fs.open("logs/bulidtime.log", "w", (err, fd) => {
+        if (err) throw Error(err.message);
+
+        logs.forEach(log => {
+          // process.stderr.write(log + " " + "\n");
+
+          fs.write(
+            fd,
+            `${chalk.yellowBright.bold(
+              `[jaamtoast-certbot]`,
+            )} ${chalk.blackBright(`${formattedTime}`)} ${log}` + "\n",
+            err => {
+              if (err) throw Error(err.message);
+            },
+          );
+        });
+      });
+    };
+  }
+
+  return () => {};
+}
+
+export function createBuildingLogDebug(debug?: boolean) {
+  if (debug) {
+    return (...logs: string[]) => {
+      const dayTime = new Date().toISOString();
+      const formattedTime = `${dayTime.split("T")[0]} ${
+        dayTime.split("T")[1].split(".")[0]
+      }`;
+
+      process.stderr.write(
+        [
+          chalk.yellowBright.bold("[building-log-debug]"),
+          chalk.blackBright(`${formattedTime}`),
+          ...logs,
+        ].join(" ") + "\n",
+      );
+
+      fs.open("logs/bulidtime.log", "w", (err, fd) => {
+        if (err) throw Error(err.message);
+
+        logs.forEach(log => {
+          // process.stderr.write(log + " " + "\n");
+
+          fs.write(
+            fd,
+            `${chalk.yellowBright.bold(
+              "[jaamtoast-building-log]",
+            )} ${chalk.blackBright(`${formattedTime}`)} ${log}` + "\n",
+            err => {
+              if (err) throw Error(err.message);
+            },
+          );
+        });
+      });
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,6 +103,14 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/abort-controller@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz#a8cd5c59d2b95c51f11e420858029bcc54af786f"
+  integrity sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/chunked-blob-reader-native@3.188.0":
   version "3.188.0"
   resolved "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.188.0.tgz"
@@ -116,6 +124,47 @@
   resolved "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz"
   integrity sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==
   dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/client-cloudwatch-logs@^3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.209.0.tgz#621901c0193e5b01ba442627739d2995ad1ee636"
+  integrity sha512-p1M3zqJsp16bN9DaPCQ5YKhaCL4Q9iLya0fjBpwEfZq8teT5s8oFnrqWWL0yIcuWpbeba8MjHTllFjZ9JKim5w==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.209.0"
+    "@aws-sdk/config-resolver" "3.209.0"
+    "@aws-sdk/credential-provider-node" "3.209.0"
+    "@aws-sdk/fetch-http-handler" "3.208.0"
+    "@aws-sdk/hash-node" "3.208.0"
+    "@aws-sdk/invalid-dependency" "3.208.0"
+    "@aws-sdk/middleware-content-length" "3.208.0"
+    "@aws-sdk/middleware-endpoint" "3.208.0"
+    "@aws-sdk/middleware-host-header" "3.208.0"
+    "@aws-sdk/middleware-logger" "3.208.0"
+    "@aws-sdk/middleware-recursion-detection" "3.208.0"
+    "@aws-sdk/middleware-retry" "3.209.0"
+    "@aws-sdk/middleware-serde" "3.208.0"
+    "@aws-sdk/middleware-signing" "3.208.0"
+    "@aws-sdk/middleware-stack" "3.208.0"
+    "@aws-sdk/middleware-user-agent" "3.208.0"
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/node-http-handler" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/smithy-client" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.209.0"
+    "@aws-sdk/util-defaults-mode-node" "3.209.0"
+    "@aws-sdk/util-endpoints" "3.209.0"
+    "@aws-sdk/util-user-agent-browser" "3.208.0"
+    "@aws-sdk/util-user-agent-node" "3.209.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/client-ec2@^3.204.0":
@@ -273,6 +322,44 @@
     fast-xml-parser "4.0.11"
     tslib "^2.3.1"
 
+"@aws-sdk/client-sso-oidc@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz#45a353b99adf00f177b47cf5559b06769a2d2506"
+  integrity sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.209.0"
+    "@aws-sdk/fetch-http-handler" "3.208.0"
+    "@aws-sdk/hash-node" "3.208.0"
+    "@aws-sdk/invalid-dependency" "3.208.0"
+    "@aws-sdk/middleware-content-length" "3.208.0"
+    "@aws-sdk/middleware-endpoint" "3.208.0"
+    "@aws-sdk/middleware-host-header" "3.208.0"
+    "@aws-sdk/middleware-logger" "3.208.0"
+    "@aws-sdk/middleware-recursion-detection" "3.208.0"
+    "@aws-sdk/middleware-retry" "3.209.0"
+    "@aws-sdk/middleware-serde" "3.208.0"
+    "@aws-sdk/middleware-stack" "3.208.0"
+    "@aws-sdk/middleware-user-agent" "3.208.0"
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/node-http-handler" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/smithy-client" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.209.0"
+    "@aws-sdk/util-defaults-mode-node" "3.209.0"
+    "@aws-sdk/util-endpoints" "3.209.0"
+    "@aws-sdk/util-user-agent-browser" "3.208.0"
+    "@aws-sdk/util-user-agent-node" "3.209.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/client-sso@3.199.0":
   version "3.199.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.199.0.tgz"
@@ -350,6 +437,44 @@
     "@aws-sdk/util-user-agent-node" "3.201.0"
     "@aws-sdk/util-utf8-browser" "3.188.0"
     "@aws-sdk/util-utf8-node" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz#61c6067842cb0af863d5cae5ef8e1c85cd67d3fd"
+  integrity sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.209.0"
+    "@aws-sdk/fetch-http-handler" "3.208.0"
+    "@aws-sdk/hash-node" "3.208.0"
+    "@aws-sdk/invalid-dependency" "3.208.0"
+    "@aws-sdk/middleware-content-length" "3.208.0"
+    "@aws-sdk/middleware-endpoint" "3.208.0"
+    "@aws-sdk/middleware-host-header" "3.208.0"
+    "@aws-sdk/middleware-logger" "3.208.0"
+    "@aws-sdk/middleware-recursion-detection" "3.208.0"
+    "@aws-sdk/middleware-retry" "3.209.0"
+    "@aws-sdk/middleware-serde" "3.208.0"
+    "@aws-sdk/middleware-stack" "3.208.0"
+    "@aws-sdk/middleware-user-agent" "3.208.0"
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/node-http-handler" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/smithy-client" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.209.0"
+    "@aws-sdk/util-defaults-mode-node" "3.209.0"
+    "@aws-sdk/util-endpoints" "3.209.0"
+    "@aws-sdk/util-user-agent-browser" "3.208.0"
+    "@aws-sdk/util-user-agent-node" "3.209.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/client-sts@3.199.0":
@@ -439,6 +564,48 @@
     fast-xml-parser "4.0.11"
     tslib "^2.3.1"
 
+"@aws-sdk/client-sts@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz#bda5bc27a1df1db9a2cfc056d9bb8bd2ff815a86"
+  integrity sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.209.0"
+    "@aws-sdk/credential-provider-node" "3.209.0"
+    "@aws-sdk/fetch-http-handler" "3.208.0"
+    "@aws-sdk/hash-node" "3.208.0"
+    "@aws-sdk/invalid-dependency" "3.208.0"
+    "@aws-sdk/middleware-content-length" "3.208.0"
+    "@aws-sdk/middleware-endpoint" "3.208.0"
+    "@aws-sdk/middleware-host-header" "3.208.0"
+    "@aws-sdk/middleware-logger" "3.208.0"
+    "@aws-sdk/middleware-recursion-detection" "3.208.0"
+    "@aws-sdk/middleware-retry" "3.209.0"
+    "@aws-sdk/middleware-sdk-sts" "3.208.0"
+    "@aws-sdk/middleware-serde" "3.208.0"
+    "@aws-sdk/middleware-signing" "3.208.0"
+    "@aws-sdk/middleware-stack" "3.208.0"
+    "@aws-sdk/middleware-user-agent" "3.208.0"
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/node-http-handler" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/smithy-client" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.209.0"
+    "@aws-sdk/util-defaults-mode-node" "3.209.0"
+    "@aws-sdk/util-endpoints" "3.209.0"
+    "@aws-sdk/util-user-agent-browser" "3.208.0"
+    "@aws-sdk/util-user-agent-node" "3.209.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    fast-xml-parser "4.0.11"
+    tslib "^2.3.1"
+
 "@aws-sdk/config-resolver@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.198.0.tgz"
@@ -461,6 +628,17 @@
     "@aws-sdk/util-middleware" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/config-resolver@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz#88132abc79aa4763e042177595f1f5288b6f3abe"
+  integrity sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/credential-provider-env@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.198.0.tgz"
@@ -477,6 +655,15 @@
   dependencies:
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz#5bc653ea24acbd1e80ee9e218fde2ecf44af7043"
+  integrity sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/credential-provider-imds@3.198.0":
@@ -499,6 +686,17 @@
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/types" "3.201.0"
     "@aws-sdk/url-parser" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz#9ad521de804abdbc8e6c9125b2c7b22d6d5aceb0"
+  integrity sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/credential-provider-ini@3.199.0":
@@ -527,6 +725,20 @@
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/shared-ini-file-loader" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz#8ddb84d63f3db0027b52afe3a2deb2e037eee8ea"
+  integrity sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.208.0"
+    "@aws-sdk/credential-provider-imds" "3.209.0"
+    "@aws-sdk/credential-provider-sso" "3.209.0"
+    "@aws-sdk/credential-provider-web-identity" "3.208.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/credential-provider-node@3.199.0":
@@ -561,6 +773,22 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/credential-provider-node@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz#f3a9612f6b14f1f0a4ab6a92a11f7a74def2d407"
+  integrity sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.208.0"
+    "@aws-sdk/credential-provider-imds" "3.209.0"
+    "@aws-sdk/credential-provider-ini" "3.209.0"
+    "@aws-sdk/credential-provider-process" "3.209.0"
+    "@aws-sdk/credential-provider-sso" "3.209.0"
+    "@aws-sdk/credential-provider-web-identity" "3.208.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/credential-provider-process@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.198.0.tgz"
@@ -579,6 +807,16 @@
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/shared-ini-file-loader" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz#6db05007ff8a49b88d602ba3ac329daa5b54d508"
+  integrity sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/credential-provider-sso@3.199.0":
@@ -603,6 +841,18 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/credential-provider-sso@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz#d8ec04bcd6d201e5913457da9a4e2ca8ad72263c"
+  integrity sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==
+  dependencies:
+    "@aws-sdk/client-sso" "3.209.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/token-providers" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/credential-provider-web-identity@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.198.0.tgz"
@@ -619,6 +869,15 @@
   dependencies:
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz#f9461bfdb05cd0e8105a877e3420245ca0698430"
+  integrity sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/eventstream-codec@3.199.0":
@@ -688,6 +947,17 @@
     "@aws-sdk/util-base64" "3.202.0"
     tslib "^2.3.1"
 
+"@aws-sdk/fetch-http-handler@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz#b7d6e46cd6fdb635498a8de12bed6611b0eff6eb"
+  integrity sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/querystring-builder" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/hash-blob-browser@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.198.0.tgz"
@@ -716,6 +986,15 @@
     "@aws-sdk/util-buffer-from" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/hash-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz#5dfeca399e1c6cfc73e1fa37479f4e32dfb42972"
+  integrity sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/hash-stream-node@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.198.0.tgz"
@@ -738,6 +1017,14 @@
   integrity sha512-f/zgntOfIozNyKSaG9dvHjjBaR3y20kYNswMYkSuCM2NIT5LpyHiiq5I11TwaocatUFcDztWpcsv7vHpIgI5Ig==
   dependencies:
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz#7efeec2b9cd89c66e2840add2dcd3aa46fd7a665"
+  integrity sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/is-array-buffer@3.188.0":
@@ -793,6 +1080,15 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-content-length@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz#72a1d85fb8650c230d6a6d2599493fe8c65e2a8b"
+  integrity sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-endpoint@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.198.0.tgz"
@@ -819,6 +1115,20 @@
     "@aws-sdk/url-parser" "3.201.0"
     "@aws-sdk/util-config-provider" "3.201.0"
     "@aws-sdk/util-middleware" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-endpoint@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.208.0.tgz#b4bfeda86cd715d230dbcae81b874831cdab2cf4"
+  integrity sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==
+  dependencies:
+    "@aws-sdk/middleware-serde" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/signature-v4" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/url-parser" "3.208.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/middleware-expect-continue@3.198.0":
@@ -860,6 +1170,15 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-host-header@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz#48beb23baae85ecace2963f5eef1df02cee285ba"
+  integrity sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-location-constraint@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.198.0.tgz"
@@ -884,6 +1203,14 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-logger@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz#f0c6dcf3d6c686fe0d1abf5fb4d02f4f0ee65373"
+  integrity sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-recursion-detection@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.198.0.tgz"
@@ -900,6 +1227,15 @@
   dependencies:
     "@aws-sdk/protocol-http" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.208.0.tgz#210200e409fedf7ae31dc591e2df1839c33d4af3"
+  integrity sha512-Dgpf5NEOYXvkQuGcbxvDovTh4HwO4ULJReGko67NJjgdZZyFS1fNykVPncxenRpsN9SJBigswYs3lwPVpqijzA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/middleware-retry@3.198.0":
@@ -923,6 +1259,18 @@
     "@aws-sdk/service-error-classification" "3.201.0"
     "@aws-sdk/types" "3.201.0"
     "@aws-sdk/util-middleware" "3.201.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-retry@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz#7508046a2bd0670b91cc000c84011b004457d9c7"
+  integrity sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/service-error-classification" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-middleware" "3.208.0"
     tslib "^2.3.1"
     uuid "^8.3.2"
 
@@ -981,6 +1329,18 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-sdk-sts@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz#fd7ea287e944b9fc99a71ca143ea49bd36b6c49b"
+  integrity sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.208.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/signature-v4" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-serde@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.198.0.tgz"
@@ -995,6 +1355,14 @@
   integrity sha512-Z7AzIuqEDvsZmp80zeT1oYxsoB8uQZby20Z8kF6/vNoq3sIzaGf/wHeNn0p+Vgo2auGSbZcVUZKoDptQLSLwIQ==
   dependencies:
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz#d16474ee3897b1c6cd52979d69cc8b36f490b771"
+  integrity sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/middleware-signing@3.198.0":
@@ -1021,6 +1389,18 @@
     "@aws-sdk/util-middleware" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-signing@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz#28e3c45f11d114704a7c78a3cfef8b6e51610126"
+  integrity sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/signature-v4" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-middleware" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-ssec@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.198.0.tgz"
@@ -1043,6 +1423,13 @@
   dependencies:
     tslib "^2.3.1"
 
+"@aws-sdk/middleware-stack@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz#8cd5da676db9f58fb5b3f8593aaab334485c413e"
+  integrity sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==
+  dependencies:
+    tslib "^2.3.1"
+
 "@aws-sdk/middleware-user-agent@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.198.0.tgz"
@@ -1059,6 +1446,15 @@
   dependencies:
     "@aws-sdk/protocol-http" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz#4fe36f9ced65a487536d23b9679c549b830d7d0d"
+  integrity sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/node-config-provider@3.198.0":
@@ -1079,6 +1475,16 @@
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/shared-ini-file-loader" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz#c621abfc1816533e5e2013b7943eb86cd1363c0c"
+  integrity sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/node-http-handler@3.199.0":
@@ -1103,6 +1509,17 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/node-http-handler@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz#69fa111ff7064e6891ae78dfc22aef86a57d7d58"
+  integrity sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.208.0"
+    "@aws-sdk/protocol-http" "3.208.0"
+    "@aws-sdk/querystring-builder" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/property-provider@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.198.0.tgz"
@@ -1119,6 +1536,14 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/property-provider@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz#d3b153ee36c92df9000f9c6f9132b70ad50596c2"
+  integrity sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/protocol-http@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.198.0.tgz"
@@ -1133,6 +1558,14 @@
   integrity sha512-RdOc1elWFpj8MogxG87nkhtylw0a+OD7W8WFM+Gw4yJMkl7cwW42VIBFfb0+KCGZfIQltIeSLRvfe3WvVPyo7Q==
   dependencies:
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz#e58d0cd04978a3ed97b6c165c1fc19ff1437139e"
+  integrity sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/querystring-builder@3.199.0":
@@ -1153,6 +1586,15 @@
     "@aws-sdk/util-uri-escape" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/querystring-builder@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz#fc2dcef63700a39739d540689c2a4b58995133ee"
+  integrity sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/querystring-parser@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.198.0.tgz"
@@ -1169,6 +1611,14 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/querystring-parser@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz#0409561bb71a67b274277e7b57ecde1b07220f9a"
+  integrity sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/service-error-classification@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.198.0.tgz"
@@ -1178,6 +1628,11 @@
   version "3.201.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.201.0.tgz#871dbc590cbc1a3e995e4d593172ad44618c155a"
   integrity sha512-Pfcfmurgq8UpM0rXco6FVblcruqN4Mo3TW8/yaXrbctWpmdNT/8v19fffQIIgk94TU8Vf/nPJ7E5DXL7MZr4Fw==
+
+"@aws-sdk/service-error-classification@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz#fb14070c7863f7637fd7ef14afe0df2949e8ec83"
+  integrity sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==
 
 "@aws-sdk/shared-ini-file-loader@3.198.0":
   version "3.198.0"
@@ -1193,6 +1648,14 @@
   integrity sha512-Pbxk0TXep0yI8MnK7Prly6JuBm5Me9AITav8/zPEgTZ3fMhXhQhhiuQcuTCI9GeosSzoiu8VvK53oPtBZZFnXQ==
   dependencies:
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/shared-ini-file-loader@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz#0f8d6ca76516a8fbe37aca4d1b446d914f5f5525"
+  integrity sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/signature-v4-multi-region@3.198.0":
@@ -1230,6 +1693,18 @@
     "@aws-sdk/util-uri-escape" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/signature-v4@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz#61f248b60c5ab34722d17e50af34f0ce7e13c63c"
+  integrity sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    "@aws-sdk/types" "3.208.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-middleware" "3.208.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/smithy-client@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.198.0.tgz"
@@ -1248,6 +1723,26 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/smithy-client@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz#61ab9ca8396b6ffb36eb4968f284cd214571491d"
+  integrity sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/token-providers@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz#fedcc8c7d8587aadd46c922db8c047a1a9b4213a"
+  integrity sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==
+  dependencies:
+    "@aws-sdk/client-sso-oidc" "3.209.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/shared-ini-file-loader" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/types@3.198.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.198.0.tgz"
@@ -1257,6 +1752,11 @@
   version "3.201.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.201.0.tgz#c248106b7a780360d6bca876036e65ca2a4e240d"
   integrity sha512-RCQj2pQyHD330Jd4c5CHJ87k2ZqC3Mmtl6nhwH1dy3vbnGUpc3q+3yinOKoTAY934kIa7ia32Y/2EjuyHxaj1A==
+
+"@aws-sdk/types@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.208.0.tgz#b674c31d6ebd34f970102b96bb128b7c2e28a670"
+  integrity sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==
 
 "@aws-sdk/url-parser@3.198.0":
   version "3.198.0"
@@ -1274,6 +1774,15 @@
   dependencies:
     "@aws-sdk/querystring-parser" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/url-parser@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz#2af6d80ed1eba61ce3fd73b48f78c1db168e25c3"
+  integrity sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-arn-parser@3.188.0":
@@ -1314,6 +1823,14 @@
     "@aws-sdk/util-buffer-from" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/util-base64@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz#36b430e5396251f761590f7c2f0c5c12193f353c"
+  integrity sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/util-body-length-browser@3.188.0":
   version "3.188.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz"
@@ -1335,6 +1852,13 @@
   dependencies:
     tslib "^2.3.1"
 
+"@aws-sdk/util-body-length-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz#baabd1fa1206ff2bd4ce3785122d86eb3258dd20"
+  integrity sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==
+  dependencies:
+    tslib "^2.3.1"
+
 "@aws-sdk/util-buffer-from@3.188.0":
   version "3.188.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz"
@@ -1351,6 +1875,14 @@
     "@aws-sdk/is-array-buffer" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/util-buffer-from@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz#285e86f6dc9030148a4147d65239e75cb254a1b0"
+  integrity sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/util-config-provider@3.188.0":
   version "3.188.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz"
@@ -1362,6 +1894,13 @@
   version "3.201.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.201.0.tgz#db6e0c8fa9a41278c927bdc7795b985f26c99d5c"
   integrity sha512-cCRJlnRRP8vrLJomzJRBIyiyohsjJKmnIaQ9t0tAhGCywZbyjx6TlpYRZYfVWo+MwdF1Pi8ZScTrFPW0JuBOIQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz#c485fd83fbac051337e5f6be60ea3f9fa61c0139"
+  integrity sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==
   dependencies:
     tslib "^2.3.1"
 
@@ -1382,6 +1921,16 @@
   dependencies:
     "@aws-sdk/property-provider" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz#a410b7d59d70cc6c2f8e1cba5f01239793e1cab1"
+  integrity sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
     bowser "^2.11.0"
     tslib "^2.3.1"
 
@@ -1409,6 +1958,18 @@
     "@aws-sdk/types" "3.201.0"
     tslib "^2.3.1"
 
+"@aws-sdk/util-defaults-mode-node@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz#515e0b0a1f82d4efc5c462840db323c64458b925"
+  integrity sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.209.0"
+    "@aws-sdk/credential-provider-imds" "3.209.0"
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/property-provider" "3.208.0"
+    "@aws-sdk/types" "3.208.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/util-endpoints@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.198.0.tgz"
@@ -1423,6 +1984,14 @@
   integrity sha512-sNees5uDp7nfEbvzaA1DAHqoEvEb9ZOkdNH5gcj/FMBETbr00YtsuXsTZogTHQsX/otRTiudZBE3iH7R4SLSAQ==
   dependencies:
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-endpoints@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz#b0a571906767da3273ec022fb0250d7b02d8b40b"
+  integrity sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-format-url@3.201.0":
@@ -1466,6 +2035,13 @@
   version "3.201.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.201.0.tgz#750bc325abd1a1b5984bda1c7314cfc024ee1b30"
   integrity sha512-iAitcEZo17IyKn4ku1IBgtomr25esu5OuSRjw5Or4bNOeqXB0w50cItf/9qft8LIhbvBEAUtNAYXvqNzvhTZdQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.208.0.tgz#e3f13d19042b34c83bb95294d26f125675bf5647"
+  integrity sha512-oXilrYpXwaPyMw1uNjL1wmR54zeFzIWx2ve1MSMheIYr26deFP3RpMfKkGXwiOvXzZ9pzTcA8shNLhg1frO/zg==
   dependencies:
     tslib "^2.3.1"
 
@@ -1523,6 +2099,15 @@
     bowser "^2.11.0"
     tslib "^2.3.1"
 
+"@aws-sdk/util-user-agent-browser@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz#cdc629bee35b24598017941e8d9324bd78dd5cb2"
+  integrity sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==
+  dependencies:
+    "@aws-sdk/types" "3.208.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
 "@aws-sdk/util-user-agent-node@3.198.0":
   version "3.198.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.198.0.tgz"
@@ -1539,6 +2124,15 @@
   dependencies:
     "@aws-sdk/node-config-provider" "3.201.0"
     "@aws-sdk/types" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.209.0":
+  version "3.209.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz#551b016611453139820224aee630e2b39de34f2a"
+  integrity sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.209.0"
+    "@aws-sdk/types" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-utf8-browser@3.188.0", "@aws-sdk/util-utf8-browser@^3.0.0":
@@ -1562,6 +2156,14 @@
   integrity sha512-A+bJFR/1rHYOJg137E69L1sX0I+LH+xf9ZjMXG9BVO0hSo7yDPoJVpHrzTJyOc3tuRITjIGBv9Qi4TKcoOSi1A==
   dependencies:
     "@aws-sdk/util-buffer-from" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz#eba17de0f92f87b98481c2e2d0ceaa05c7994d67"
+  integrity sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-waiter@3.198.0":
@@ -1734,6 +2336,11 @@
   resolved "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
 "@testing-library/dom@^8.11.1":
   version "8.19.0"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz"
@@ -1774,6 +2381,11 @@
   integrity sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==
   dependencies:
     "@types/express" "*"
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/cors@^2.8.12":
   version "2.8.12"
@@ -1857,6 +2469,11 @@
   version "18.8.5"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz"
   integrity sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==
+
+"@types/node@>=10.0.0":
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/qs@*":
   version "6.9.7"
@@ -1982,7 +2599,7 @@ abbrev@1:
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.5:
+accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -2112,6 +2729,11 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+base64id@2.0.0, base64id@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
+
 basic-auth@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz"
@@ -2198,6 +2820,14 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -2206,14 +2836,6 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chokidar@^3.5.2:
   version "3.5.3"
@@ -2352,7 +2974,12 @@ cookie@0.4.1:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
-cors@^2.8.5:
+cookie@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cors@^2.8.5, cors@~2.8.5:
   version "2.8.5"
   resolved "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
@@ -2381,7 +3008,7 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.x, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4.x, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2490,6 +3117,27 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+engine.io-parser@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
+  integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
+
+engine.io@~6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.2.0.tgz#003bec48f6815926f2b1b17873e576acd54f41d0"
+  integrity sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.2.3"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.4"
@@ -4227,6 +4875,31 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
+socket.io-adapter@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
+  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
+
+socket.io-parser@~4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
+  integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.3.tgz#44dffea48d7f5aa41df4a66377c386b953bc521c"
+  integrity sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    debug "~4.3.2"
+    engine.io "~6.2.0"
+    socket.io-adapter "~2.4.0"
+    socket.io-parser "~4.2.0"
+
 socks@^2.6.2, socks@^2.7.0:
   version "2.7.1"
   resolved "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz"
@@ -4574,6 +5247,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@~8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Task

- [building 로그 실시간 프론트 전달 & socket 세팅](https://taewan.notion.site/building-c4f9fd3cd3ea4c31b4a244c66cdc7940)

## Description

- Socket.io Express 오리진 서버에서 사용을 더 편하게 할 수 있도록 Singlenton 패턴을 활용해서 세팅
- AWS SDK client-cloudwatch-logs 세팅 (`DescribeLogStreamsCommand`, `FilterLogEventsCommand`)
  - EC2 instance 를 생성할 때 실행하는 user-data 명령어의 output—로그, log— 내용들이 cloudwatch 에 저장되고, 
  - 로그가 저장되었는지 `describeLogStreams` 로 확인 후, 
  - `getFilteredLogEvents` 함수로 저장된 로그를 jaamtoast origin 서버로 불러옵니다.
  - jaamtoast origin 서버로 불러온 로그를 `createDebug` 로거 함수를 통해서 `bulidtime.log` 라는 파일에 저장하고
  - socket 에서 `builtime.log` 파일의 변경을 감지할 때, 그 내용을 client 로 전달합니다.

## Key Points

- `createDebug` 로거 함수에 추후 디버깅 활용을 위한 몇 줄이 주석 처리 되어있습니다

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
  - Is function reusable (cacheable) and pure? (If it's possible)
  - No random values
  - No current date/time
  - No global state (DOM, files, db, etc)
  - No mutation of parameters

## Anything to add

- 
