### PR TITLE
✨ feat: set up delete-deployment feature

### DIFF
--- a/src/api/controllers/deployController/deployCertbot.ts
+++ b/src/api/controllers/deployController/deployCertbot.ts
@@ -32,6 +32,7 @@ const deployCertbot = catchAsync(async (req, res, next) => {
     instanceId as string,
     recordId as string,
     repoName,
+    req.deploymentData,
   );
 
   debug(`Successfully requested for a certificate`);

--- a/src/api/controllers/deployController/deployDomain.ts
+++ b/src/api/controllers/deployController/deployDomain.ts
@@ -1,7 +1,7 @@
 import Config from "../../../config";
 
 import describeInstanceIp from "../../../deploy/aws/ec2_describeinstances";
-import createDNSRecord from "../../../deploy/aws/route53_createrecord";
+import changeDNSRecord from "../../../deploy/aws/route53_changerecord";
 
 import catchAsync from "../../../utils/asyncHandler";
 import { DeploymentError } from "../../../utils/errors";
@@ -23,7 +23,7 @@ const deployDomain = catchAsync(async (req, res, next) => {
     const publicIpAddressInterval = setInterval(getPublicIpAddress, 2000);
 
     async function getPublicIpAddress() {
-      const instanceChangeInfo = await describeInstanceIp(instanceId as string);
+      const instanceChangeInfo = await describeInstanceIp(instanceId);
 
       publicIpAddress = instanceChangeInfo?.publicIpAddress;
 
@@ -32,14 +32,15 @@ const deployDomain = catchAsync(async (req, res, next) => {
       if (publicIpAddress) {
         debug(`Created instance public IP: ${publicIpAddress}`);
 
-        const createDNSRecordInput = {
+        const changeDNSRecordInput = {
+          actionType: "CREATE",
           subdomain: repoName,
           recordValue: publicIpAddress,
           recordType: RRType.A,
         };
 
         if (recordIdStatus !== "PENDING" && recordIdStatus !== "INSYNC") {
-          recordChangeInfo = await createDNSRecord(createDNSRecordInput);
+          recordChangeInfo = await changeDNSRecord(changeDNSRecordInput);
         }
 
         if (!recordChangeInfo) {

--- a/src/api/controllers/deployController/deployFilterData.ts
+++ b/src/api/controllers/deployController/deployFilterData.ts
@@ -35,6 +35,8 @@ const deployFilterData = catchAsync(async (req, res, next) => {
     buildType,
     buildingLog,
     lastCommitMessage,
+    repoId,
+    webhookId,
   } = req.deploymentData;
 
   const userDeploymentData = {
@@ -51,6 +53,8 @@ const deployFilterData = catchAsync(async (req, res, next) => {
     buildingLog,
     instanceId,
     lastCommitMessage,
+    repoId,
+    webhookId,
   };
 
   debug(

--- a/src/api/controllers/deployController/deployFilterData.ts
+++ b/src/api/controllers/deployController/deployFilterData.ts
@@ -49,6 +49,7 @@ const deployFilterData = catchAsync(async (req, res, next) => {
     buildType,
     deployedUrl,
     buildingLog,
+    instanceId,
     lastCommitMessage,
   };
 
@@ -56,7 +57,7 @@ const deployFilterData = catchAsync(async (req, res, next) => {
     "Sending back to client of the newly created deployment buliding log...",
   );
 
-  return res.json({
+  return res.status(201).json({
     result: "ok",
     data: userDeploymentData,
   });

--- a/src/api/controllers/deployController/deployInstance.ts
+++ b/src/api/controllers/deployController/deployInstance.ts
@@ -51,7 +51,7 @@ const deployInstance = catchAsync(async (req, res, next) => {
     lastCommitMessage,
   };
 
-  bulidingLogSocket();
+  await bulidingLogSocket();
 
   const { deployedUrl, instanceId } = await createDeploymentInstance(
     repoBuildOptions,
@@ -61,13 +61,20 @@ const deployInstance = catchAsync(async (req, res, next) => {
     return next(createError(401));
   }
 
-  createRepoWebhook(githubAccessToken as string, repoOwner, repoName);
+  const newWebhookData = await createRepoWebhook(
+    githubAccessToken as string,
+    repoOwner,
+    repoName,
+  );
+
+  const webhookId = newWebhookData.id.toString();
 
   req.deploymentData = {
     ...repoBuildOptions,
     instanceId,
     deployedUrl,
     lastCommitMessage,
+    webhookId,
   };
 
   next();

--- a/src/api/controllers/deployController/deployInstance.ts
+++ b/src/api/controllers/deployController/deployInstance.ts
@@ -2,7 +2,7 @@ import createError from "http-errors";
 
 import createDeploymentInstance from "../../../deploy/build-utils/createDeploymentInstance";
 import { bulidingLogSocket } from "../../../deploy/socket";
-import { createRepoWebhook } from "../../github/client";
+import { createRepoWebhook, getCommits } from "../../github/client";
 
 import catchAsync from "../../../utils/asyncHandler";
 
@@ -29,6 +29,15 @@ const deployInstance = catchAsync(async (req, res, next) => {
   }
 
   const repoOwner = repoCloneUrl.split("https://github.com/")[1].split("/")[0];
+
+  const commitList = await getCommits(
+    githubAccessToken as string,
+    repoOwner,
+    repoName,
+  );
+
+  const lastCommitMessage = commitList[0].commit.message;
+
   const repoBuildOptions = {
     repoOwner,
     repoName,
@@ -39,6 +48,7 @@ const deployInstance = catchAsync(async (req, res, next) => {
     buildCommand,
     envList,
     buildType,
+    lastCommitMessage,
   };
 
   bulidingLogSocket();
@@ -57,6 +67,7 @@ const deployInstance = catchAsync(async (req, res, next) => {
     ...repoBuildOptions,
     instanceId,
     deployedUrl,
+    lastCommitMessage,
   };
 
   next();

--- a/src/api/controllers/deployController/deployLogs.ts
+++ b/src/api/controllers/deployController/deployLogs.ts
@@ -27,6 +27,7 @@ const deployLogs = catchAsync(async (req, res, next) => {
   const filteredLogEventMessages = await runGetFilteredLogEvents(
     instanceId as string,
     repoName,
+    req.deploymentData,
   );
 
   req.deploymentData.buildingLog = filteredLogEventMessages;

--- a/src/api/controllers/deployController/deploySaveData.ts
+++ b/src/api/controllers/deployController/deploySaveData.ts
@@ -1,4 +1,4 @@
-import { startSession } from "mongoose";
+import { startSession, Types } from "mongoose";
 
 import Config from "../../../config";
 
@@ -38,6 +38,7 @@ const deploySaveData = catchAsync(async (req, res, next) => {
   }
 
   const session = await startSession();
+  let repoId: Types.ObjectId;
 
   await session.withTransaction(async () => {
     const newRepoArr = await Repo.create(
@@ -50,12 +51,15 @@ const deploySaveData = catchAsync(async (req, res, next) => {
     );
 
     const newRepo = newRepoArr[0].toObject();
+    repoId = newRepo._id;
 
     await User.updateOne(
       { _id: user_id },
       { $push: { myRepos: newRepo._id } },
       { session, new: true },
     );
+
+    req.deploymentData.repoId = repoId;
   });
 
   session.endSession();

--- a/src/api/controllers/deployController/getUserDeployList.ts
+++ b/src/api/controllers/deployController/getUserDeployList.ts
@@ -5,22 +5,22 @@ import Config from "../../../config";
 import { DBUser, User } from "../../../models/User";
 
 import catchAsync from "../../../utils/asyncHandler";
-import { DeploymentError } from "../../../utils/errors";
-import { createDeploymentDebug } from "../../../utils/createDebug";
+import { CustomError } from "../../../utils/errors";
+import { createGeneralLogDebug } from "../../../utils/createDebug";
 
 import { DBRepo } from "../../../models/Repo";
 
 const getUserDeployList = catchAsync(async (req, res, next) => {
-  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+  const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
 
   const { user_id } = req.params;
 
   if (!user_id) {
-    debug("Error: 'user_id' is expected to be strings");
+    debug("Error: 'user_id' is expected to be a string");
 
     return next(
-      new DeploymentError({
-        code: "getUserDeployList",
+      new CustomError({
+        code: "400: getUserDeployList",
         message: "'user_id' is typeof undefined",
       }),
     );

--- a/src/api/controllers/deployController/getUserDeployList.ts
+++ b/src/api/controllers/deployController/getUserDeployList.ts
@@ -2,13 +2,13 @@ import { LeanDocument } from "mongoose";
 
 import Config from "../../../config";
 
-import { User } from "../../../models/User";
+import { DBUser, User } from "../../../models/User";
 
 import catchAsync from "../../../utils/asyncHandler";
 import { DeploymentError } from "../../../utils/errors";
 import { createDeploymentDebug } from "../../../utils/createDebug";
 
-import { DeploymentData } from "../../../types/custom";
+import { DBRepo } from "../../../models/Repo";
 
 const getUserDeployList = catchAsync(async (req, res, next) => {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
@@ -26,10 +26,10 @@ const getUserDeployList = catchAsync(async (req, res, next) => {
     );
   }
 
-  let userDeployList: LeanDocument<DeploymentData>[] | undefined = [];
+  let userDeployList: LeanDocument<DBRepo>[] | undefined = [];
 
-  const userData = await User.findOne({ _id: user_id })
-    .populate<{ myRepos: DeploymentData[] }>("myRepos")
+  const userData = await User.findOne<DBUser>({ _id: user_id })
+    .populate<{ myRepos: DBRepo[] }>("myRepos")
     .lean();
 
   userDeployList = userData?.myRepos || [];
@@ -47,7 +47,9 @@ const getUserDeployList = catchAsync(async (req, res, next) => {
       buildType,
       deployedUrl,
       buildingLog,
+      instanceId,
       lastCommitMessage,
+      _id,
     } = deployData;
 
     const filteredDeployData = {
@@ -62,7 +64,9 @@ const getUserDeployList = catchAsync(async (req, res, next) => {
       buildType,
       deployedUrl,
       buildingLog,
+      instanceId,
       lastCommitMessage,
+      repoId: _id,
     };
 
     return filteredDeployData;

--- a/src/api/controllers/updateController/deleteDeployment.ts
+++ b/src/api/controllers/updateController/deleteDeployment.ts
@@ -19,7 +19,7 @@ import deleteLogStream from "../../../deploy/aws/cwl_deletelogstream";
 const deleteDeployment = catchAsync(async (req, res, next) => {
   const { githubAccessToken } = req.query;
   const { user_id, repo_id } = req.params;
-  const { instanceId, repoName } = req.body;
+  const { instanceId, repoName, repoOwner, webhookId } = req.body;
 
   const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
 

--- a/src/api/controllers/updateController/deleteDeployment.ts
+++ b/src/api/controllers/updateController/deleteDeployment.ts
@@ -59,6 +59,8 @@ const deleteDeployment = catchAsync(async (req, res, next) => {
     );
   }
 
+  await deleteLogStream(instanceId);
+
   return res.json({
     result: "ok",
   });

--- a/src/api/controllers/updateController/deleteDeployment.ts
+++ b/src/api/controllers/updateController/deleteDeployment.ts
@@ -1,0 +1,67 @@
+import { startSession } from "mongoose";
+
+import Config from "../../../config";
+import catchAsync from "../../../utils/asyncHandler";
+
+import terminateInstance from "../../../deploy/aws/ec2_terminateinstances";
+import changeDNSRecord from "../../../deploy/aws/route53_changerecord";
+import describeInstanceIp from "../../../deploy/aws/ec2_describeinstances";
+
+import { User } from "../../../models/User";
+import { Repo } from "../../../models/Repo";
+
+import { RRType } from "@aws-sdk/client-route-53";
+import deleteLogStream from "../../../deploy/aws/cwl_deletelogstream";
+
+const deleteDeployment = catchAsync(async (req, res, next) => {
+  const { githubAccessToken } = req.query;
+  const { user_id, repo_id } = req.params;
+  const { instanceId, repoName } = req.body;
+
+  const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
+
+  if (!githubAccessToken || !user_id || !repo_id || !instanceId || !repoName) {
+    return next(
+    );
+  }
+
+  const session = await startSession();
+
+  await session.withTransaction(async () => {
+    await User.updateOne({ _id: user_id }, { $pull: { myRepos: repo_id } });
+
+    await Repo.findByIdAndDelete(repo_id);
+  });
+
+  session.endSession();
+
+  await terminateInstance(instanceId);
+
+  const instanceChangeInfo = await describeInstanceIp(instanceId);
+
+  if (!instanceChangeInfo) {
+    return next(
+    );
+  }
+
+  const publicIpAddress = instanceChangeInfo.publicIpAddress;
+  const changeDNSRecordInput = {
+    actionType: "DELETE",
+    subdomain: repoName as string,
+    recordValue: publicIpAddress as string,
+    recordType: RRType.A,
+  };
+
+  const recordChangeInfo = await changeDNSRecord(changeDNSRecordInput);
+
+  if (!recordChangeInfo) {
+    return next(
+    );
+  }
+
+  return res.json({
+    result: "ok",
+  });
+});
+
+export default deleteDeployment;

--- a/src/api/controllers/updateController/index.ts
+++ b/src/api/controllers/updateController/index.ts
@@ -1,3 +1,4 @@
 import updateDeployment from "./updateDeployment";
+import deleteDeployment from "./deleteDeployment";
 
-export { updateDeployment };
+export { updateDeployment, deleteDeployment };

--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -1,8 +1,7 @@
 import createError from "http-errors";
 
-import { getRepos, getOrgs, getOrgRepos } from "../github/client";
-
 import catchAsync from "../../utils/asyncHandler";
+import { getRepos, getOrgs, getOrgRepos } from "../github/client";
 
 export const getOrganizations = catchAsync(async (req, res, next) => {
   const { githubAccessToken } = req.query;

--- a/src/api/github/client.ts
+++ b/src/api/github/client.ts
@@ -14,6 +14,8 @@ type ListUserOrgsResponse = Endpoints["GET /users/{username}/orgs"]["response"];
 type ListOrgReposResponse = Endpoints["GET /orgs/{org}/repos"]["response"];
 type CreateWebhookResponse =
   Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+type DeleteWebhookResponse =
+  Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
 type ListCommtisResponse =
   Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
 type PullRequestCommitResponse =
@@ -91,7 +93,7 @@ export const createRepoWebhook = async (
   repoOwner: string,
   repoName: string,
 ) => {
-  const { data } = await GithubClient.post<CreateWebhookResponse>(
+  const { data } = await GithubClient.post<CreateWebhookResponse["data"]>(
     `/repos/${repoOwner}/${repoName}/hooks`,
     {
       name: "web",
@@ -114,6 +116,31 @@ export const createRepoWebhook = async (
       },
     },
   );
+
+  return data;
+};
+
+export const deleteRepoWebhook = async (
+  accessToken: string,
+  repoOwner: string,
+  repoName: string,
+  webhookId: number,
+) => {
+  const { data } = await GithubClient.delete<DeleteWebhookResponse>(
+    `/repos/${repoOwner}/${repoName}/hooks/${webhookId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      params: {
+        owner: `${repoOwner}`,
+        repo: `${repoName}`,
+        hook_id: `${webhookId}`,
+      },
+    },
+  );
+
+  return data;
 };
 
 export const getCommits = async (

--- a/src/api/github/client.ts
+++ b/src/api/github/client.ts
@@ -14,6 +14,8 @@ type ListUserOrgsResponse = Endpoints["GET /users/{username}/orgs"]["response"];
 type ListOrgReposResponse = Endpoints["GET /orgs/{org}/repos"]["response"];
 type CreateWebhookResponse =
   Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+type ListCommtisResponse =
+  Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
 type PullRequestCommitResponse =
   Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["response"];
 
@@ -112,6 +114,23 @@ export const createRepoWebhook = async (
       },
     },
   );
+};
+
+export const getCommits = async (
+  accessToken: string,
+  repoOwner: string,
+  repoName: string,
+) => {
+  const { data } = await GithubClient.get<ListCommtisResponse["data"]>(
+    `/repos/${repoOwner}/${repoName}/commits`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  return data;
 };
 
 export const getHeadCommitMessage = async (

--- a/src/api/middlewares/errorHandler.ts
+++ b/src/api/middlewares/errorHandler.ts
@@ -11,6 +11,12 @@ const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
         req.originalUrl
       } - ${req.method} - ${req.ip}`,
     );
+  } else if (err.name === "CustomError") {
+    Logger.error(
+      `${err.status || 500} - ${err.code} - ${err.message} - ${
+        req.originalUrl
+      } - ${req.method} - ${req.ip}`,
+    );
   } else {
     Logger.error(
       `${err.status || 500} - ${err.message} - ${req.originalUrl} - ${

--- a/src/api/middlewares/verifyToken.ts
+++ b/src/api/middlewares/verifyToken.ts
@@ -4,7 +4,7 @@ import jwt from "jsonwebtoken";
 
 import Config from "../../config";
 
-import { User } from "../../types/custom";
+import { UserType } from "../../types/custom";
 
 const verifyToken: RequestHandler = (req, res, next) => {
   const authToken = req.headers.authorization;
@@ -35,7 +35,7 @@ const verifyToken: RequestHandler = (req, res, next) => {
     return next(createError(401));
   }
 
-  req.user = verifiedUserData as User;
+  req.user = verifiedUserData as UserType;
 
   next();
 };

--- a/src/api/routes/deploy.ts
+++ b/src/api/routes/deploy.ts
@@ -6,6 +6,7 @@ import verifyToken from "../middlewares/verifyToken";
 import validateSchema from "../middlewares/validateSchema";
 
 import * as DeployController from "../controllers/deployController";
+import * as UpdateController from "../controllers/updateController";
 
 const route = Router();
 
@@ -37,6 +38,17 @@ const deployRouter = (app: Router) => {
       "params[user_id]",
     ),
     DeployController.getUserDeployList,
+  );
+
+  route.delete(
+    "/:user_id/:repo_id",
+    validateSchema(
+      Joi.object({
+        user_id: Joi.string().regex(/^[a-f\d]{24}$/i),
+      }),
+      "params[user_id]",
+    ),
+    UpdateController.deleteDeployment,
   );
 };
 

--- a/src/deploy/aws/cwl_deletelogstream.ts
+++ b/src/deploy/aws/cwl_deletelogstream.ts
@@ -3,6 +3,9 @@ import { DeleteLogStreamCommand } from "@aws-sdk/client-cloudwatch-logs";
 import Config from "../../config";
 import cwlClient from "./libs/cloudWatchLogsClient";
 
+import { CustomError } from "../../utils/errors";
+import { createGeneralLogDebug } from "../../utils/createDebug";
+
 const deleteLogStream = async (instanceId: string) => {
   const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
 
@@ -15,7 +18,16 @@ const deleteLogStream = async (instanceId: string) => {
     const command = new DeleteLogStreamCommand(logStreamsParams);
 
     const data = await cwlClient.send(command);
+
+    debug(`Successfully deleted a user-data.log of ${instanceId} - ${data}`);
   } catch (err) {
+    debug(
+      `Error: An unexpected error occurred during DeleteLogStreamCommand_user-data.log - ${err}`,
+    );
+    throw new CustomError({
+      code: "cloudWatchLogsClient_DeleteLogStreamCommand_user-data.log",
+      message: "DeleteLogStreamCommand_user-data.log didn't work as expected",
+    });
   }
 };
 

--- a/src/deploy/aws/cwl_deletelogstream.ts
+++ b/src/deploy/aws/cwl_deletelogstream.ts
@@ -1,0 +1,22 @@
+import { DeleteLogStreamCommand } from "@aws-sdk/client-cloudwatch-logs";
+
+import Config from "../../config";
+import cwlClient from "./libs/cloudWatchLogsClient";
+
+const deleteLogStream = async (instanceId: string) => {
+  const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
+
+  const logStreamsParams = {
+    logGroupName: "user-data.log",
+    logStreamName: instanceId,
+  };
+
+  try {
+    const command = new DeleteLogStreamCommand(logStreamsParams);
+
+    const data = await cwlClient.send(command);
+  } catch (err) {
+  }
+};
+
+export default deleteLogStream;

--- a/src/deploy/aws/ec2_describeinstances.ts
+++ b/src/deploy/aws/ec2_describeinstances.ts
@@ -3,16 +3,16 @@ import { DescribeInstancesCommand } from "@aws-sdk/client-ec2";
 import Config from "../../config";
 import ec2Client from "./libs/ec2Client";
 
-import { DeploymentError } from "../../utils/errors";
-import { createDeploymentDebug } from "../../utils/createDebug";
+import { CustomError } from "../../utils/errors";
+import { createGeneralLogDebug } from "../../utils/createDebug";
 
 const describeInstanceIp = async (instanceId: string) => {
-  const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
+  const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
 
-  const instancesParams = { InstanceIds: [instanceId] };
+  const instanceParams = { InstanceIds: [instanceId] };
 
   try {
-    const command = new DescribeInstancesCommand(instancesParams);
+    const command = new DescribeInstancesCommand(instanceParams);
 
     const data = await ec2Client.send(command);
 
@@ -40,7 +40,7 @@ const describeInstanceIp = async (instanceId: string) => {
     debug(
       `Error: An unexpected error occurred during DescribeInstancesCommand - ${err}`,
     );
-    throw new DeploymentError({
+    throw new CustomError({
       code: "ec2Client_DescribeInstancesCommand",
       message: "DescribeInstancesCommand didn't work as expected",
     });

--- a/src/deploy/aws/ec2_terminateinstances.ts
+++ b/src/deploy/aws/ec2_terminateinstances.ts
@@ -1,0 +1,19 @@
+import { TerminateInstancesCommand } from "@aws-sdk/client-ec2";
+
+import Config from "../../config";
+import ec2Client from "./libs/ec2Client";
+
+const terminateInstance = async (instanceId: string) => {
+  const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
+
+  const instanceParams = { InstanceIds: [instanceId], DryRun: false };
+
+  try {
+    const command = new TerminateInstancesCommand(instanceParams);
+
+    const data = await ec2Client.send(command);
+  } catch (err) {
+  }
+};
+
+export default terminateInstance;

--- a/src/deploy/aws/ec2_terminateinstances.ts
+++ b/src/deploy/aws/ec2_terminateinstances.ts
@@ -3,6 +3,9 @@ import { TerminateInstancesCommand } from "@aws-sdk/client-ec2";
 import Config from "../../config";
 import ec2Client from "./libs/ec2Client";
 
+import { CustomError } from "../../utils/errors";
+import { createGeneralLogDebug } from "../../utils/createDebug";
+
 const terminateInstance = async (instanceId: string) => {
   const debug = createGeneralLogDebug(Config.CLIENT_OPTIONS.debug);
 
@@ -12,7 +15,16 @@ const terminateInstance = async (instanceId: string) => {
     const command = new TerminateInstancesCommand(instanceParams);
 
     const data = await ec2Client.send(command);
+
+    debug(`Successfully terminated an instance (${instanceId}) - ${data}`);
   } catch (err) {
+    debug(
+      `Error: An unexpected error occurred during TerminateInstancesCommand - ${err}`,
+    );
+    throw new CustomError({
+      code: "ec2Client_TerminateInstancesCommand",
+      message: "TerminateInstancesCommand didn't work as expected",
+    });
   }
 };
 

--- a/src/deploy/aws/route53_changerecord.ts
+++ b/src/deploy/aws/route53_changerecord.ts
@@ -9,13 +9,14 @@ import route53Client from "./libs/route53Client";
 import { DeploymentError } from "../../utils/errors";
 import { createDeploymentDebug } from "../../utils/createDebug";
 
-import { CreateDNSRecordProps } from "../../types/custom";
+import { ChangeDNSRecordProps } from "../../types/custom";
 
-const createDNSRecord = async ({
+const changeDNSRecord = async ({
+  actionType,
   subdomain,
   recordValue,
   recordType = RRType.A,
-}: CreateDNSRecordProps) => {
+}: ChangeDNSRecordProps) => {
   const debug = createDeploymentDebug(Config.CLIENT_OPTIONS.debug);
 
   const recordName = `${subdomain}.${Config.SERVER_URL}`;
@@ -23,10 +24,10 @@ const createDNSRecord = async ({
   const recordParams = {
     HostedZoneId: Config.HOSTED_ZONE_ID,
     ChangeBatch: {
-      Comment: "CREATE a record A",
+      Comment: `${actionType} a record A`,
       Changes: [
         {
-          Action: "CREATE",
+          Action: `${actionType}`,
           ResourceRecordSet: {
             Name: recordName,
             Type: recordType,
@@ -56,13 +57,13 @@ const createDNSRecord = async ({
     }
   } catch (err) {
     debug(
-      `Error: An unexpected error occurred during ChangeResourceRecordSetsCommand - ${err}`,
+      `Error: An unexpected error occurred during ChangeResourceRecordSetsCommand_${actionType} - ${err}`,
     );
     throw new DeploymentError({
-      code: "route53Client_ChangeResourceRecordSetsCommand",
-      message: "ChangeResourceRecordSetsCommand didn't work as expected",
+      code: `route53Client_ChangeResourceRecordSetsCommand_${actionType}`,
+      message: `ChangeResourceRecordSetsCommand_${actionType} didn't work as expected`,
     });
   }
 };
 
-export default createDNSRecord;
+export default changeDNSRecord;

--- a/src/models/Repo.ts
+++ b/src/models/Repo.ts
@@ -20,6 +20,7 @@ export interface DBRepo {
   recordId?: string;
   buildingLog?: (string | undefined)[] | undefined;
   lastCommitMessage?: string;
+  webhookId?: string;
 }
 
 const Joigoose = joigoose(mongoose);
@@ -43,6 +44,7 @@ const joiRepoSchema = joi.object({
   buildingLog: joi.array().items(joi.string()),
   deployedUrl: joi.string().allow(""),
   lastCommitMessage: joi.string(),
+  webhookId: joi.string(),
 });
 
 const repoSchema = new mongoose.Schema(Joigoose.convert(joiRepoSchema), {

--- a/src/models/Repo.ts
+++ b/src/models/Repo.ts
@@ -1,8 +1,26 @@
-import mongoose from "mongoose";
+import mongoose, { Types } from "mongoose";
 import joi from "joi";
 import joigoose from "joigoose";
 
-import { DeploymentData } from "../types/custom";
+import { Env } from "../types/custom";
+
+export interface DBRepo {
+  _id: Types.ObjectId;
+  repoName: string;
+  repoOwner: string;
+  repoCloneUrl: string;
+  repoUpdatedAt: string;
+  nodeVersion: string;
+  installCommand: string;
+  buildCommand: string;
+  buildType: string;
+  envList?: Env[];
+  instanceId: string;
+  deployedUrl?: string;
+  recordId?: string;
+  buildingLog?: (string | undefined)[] | undefined;
+  lastCommitMessage?: string;
+}
 
 const Joigoose = joigoose(mongoose);
 
@@ -30,6 +48,6 @@ const joiRepoSchema = joi.object({
 const repoSchema = new mongoose.Schema(Joigoose.convert(joiRepoSchema), {
   versionKey: false,
 });
-const Repo = mongoose.model<DeploymentData>("Repo", repoSchema);
+const Repo = mongoose.model<DBRepo>("Repo", repoSchema);
 
 export { Repo, joiRepoSchema };

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,8 +1,15 @@
-import mongoose from "mongoose";
+import mongoose, { Types } from "mongoose";
 import joi from "joi";
 import joigoose from "joigoose";
 
-import { User } from "../types/custom";
+export interface DBUser {
+  _id: Types.ObjectId;
+  username: string;
+  userGithubUri: string;
+  userImage?: string;
+  githubAccessToken?: string;
+  myRepos?: Types.ObjectId[];
+}
 
 const Joigoose = joigoose(mongoose);
 
@@ -21,6 +28,6 @@ const joiUserSchema = joi.object({
 const userSchema = new mongoose.Schema(Joigoose.convert(joiUserSchema), {
   versionKey: false,
 });
-const User = mongoose.model<User>("User", userSchema);
+const User = mongoose.model<DBUser>("User", userSchema);
 
 export { User, joiUserSchema };

--- a/src/types/custom/index.d.ts
+++ b/src/types/custom/index.d.ts
@@ -44,6 +44,8 @@ export interface DeploymentData extends RepoBuildOptions {
   recordId?: string;
   buildingLog?: (string | undefined)[] | undefined;
   lastCommitMessage?: string;
+  webhookId?: string;
+  repoId?: Types.ObjectId;
 }
 
 interface ChangeDNSRecordProps {

--- a/src/types/custom/index.d.ts
+++ b/src/types/custom/index.d.ts
@@ -46,6 +46,8 @@ export interface DeploymentData extends RepoBuildOptions {
   lastCommitMessage?: string;
   webhookId?: string;
   repoId?: Types.ObjectId;
+  publicIpAddress?: string;
+  githubAccessToken?: string;
 }
 
 interface ChangeDNSRecordProps {

--- a/src/types/custom/index.d.ts
+++ b/src/types/custom/index.d.ts
@@ -1,7 +1,7 @@
 import { RRType, Date } from "@aws-sdk/client-route-53";
 import { Types } from "mongoose";
 
-export interface User {
+export interface UserType {
   username: string;
   userGithubUri: string;
   userImage?: string;
@@ -46,7 +46,8 @@ export interface DeploymentData extends RepoBuildOptions {
   lastCommitMessage?: string;
 }
 
-interface CreateDNSRecordProps {
+interface ChangeDNSRecordProps {
+  actionType: string;
   subdomain: string;
   recordValue: string;
   recordType: RRType;

--- a/src/utils/createDebug.ts
+++ b/src/utils/createDebug.ts
@@ -100,3 +100,36 @@ export function createBuildingLogDebug(debug?: boolean) {
 
   return () => {};
 }
+
+export function createGeneralLogDebug(debug?: boolean) {
+  if (debug) {
+    return (...logs: string[]) => {
+      const dayTime = new Date().toISOString();
+      const formattedTime = `${dayTime.split("T")[0]} ${
+        dayTime.split("T")[1].split(".")[0]
+      }.${dayTime.split(".")[1].split("Z")[0]}`;
+
+      process.stderr.write(
+        [
+          chalk.redBright.bold("[general-log-debug]"),
+          chalk.blackBright(`${formattedTime}`),
+          ...logs,
+        ].join(" ") + "\n",
+      );
+
+      fs.open("logs/bulidtime.log", "w", (err, fd) => {
+        if (err) throw Error(err.message);
+
+        logs.forEach(log => {
+          // process.stderr.write(log + " " + "\n");
+
+          fs.write(fd, `[general-log] ${formattedTime} ${log}` + "\n", err => {
+            if (err) throw Error(err.message);
+          });
+        });
+      });
+    };
+  }
+
+  return () => {};
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,3 +7,13 @@ export class DeploymentError extends Error {
 
   code: string;
 }
+
+export class CustomError extends Error {
+  constructor(err: { code: string; message: string }) {
+    super(err.message);
+    this.code = err.code;
+    this.name = "CustomError";
+  }
+
+  code: string;
+}


### PR DESCRIPTION
## Task

- [유저배포 삭제 & 배포 중 에러 시 롤백](https://taewan.notion.site/42ec3577f1614a3fb38cbd43ea75e354)

## Description

- 유저의 배포 관련 데이터 삭제
  - database 에서 관련 내용 삭제
    - Repo model 의 해당 레포
    - User model 의 레포 ref
  - 배포를 위해 만들어졌던 aws resources 삭제
    - EC2 instance
    - Route53 record
    - CloudWatch logStream
- deployDomain / deployCertbot / deployLogs 의 배포 단계 별 에러 롤백
  - 실패할 경우 이미 만들어진 aws resources 삭제 
- 관련 플로우에 사용하기 위해 debug 와 커스텀에러 추가

## Key Points

- 

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
  - Is function reusable (cacheable) and pure? (If it's possible)
  - No random values
  - No current date/time
  - No global state (DOM, files, db, etc)
  - No mutation of parameters

## Anything to add

- 
