### PR TITLE
✨ feat: p1; create projects route / change db models

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -3,7 +3,7 @@ import jwt from "jsonwebtoken";
 
 import Config from "@src/config";
 import catchAsync from "@src/controllers/utils/asyncHandler";
-import UserModel from "@src/models/User";
+import UserModel from "@src/services/DBService/user";
 
 export const login = catchAsync(async (req, res, next) => {
   const { username, userGithubUri, userImage, githubAccessToken } = req.user;
@@ -12,7 +12,7 @@ export const login = catchAsync(async (req, res, next) => {
     return next(createError(401));
   }
 
-  let userData = await UserModel.findOne({ userGithubUri });
+  let userData = await UserModel.findByProperty({ userGithubUri });
 
   if (!userData) {
     userData = await UserModel.create({

--- a/src/controllers/project.ts
+++ b/src/controllers/project.ts
@@ -1,0 +1,202 @@
+import createError from "http-errors";
+
+import Config from "@src/config";
+import catchAsync from "@src/controllers/utils/asyncHandler";
+import UserModel from "@src/services/DBService/user";
+import ProjectModel from "@src/services/DBService/project";
+import DeploymentModel from "@src/services/DBService/deployment";
+import GithubClient from "@src/services/GithubClient";
+import ProjectService from "@src/services/ProjectService";
+
+export const createProject = catchAsync(async (req, res, next) => {
+  const buildOption = req.body;
+  const { githubAccessToken } = req.query;
+  const { userId, space, repository } = buildOption;
+
+  const newProject = await ProjectModel.create({
+    ...buildOption,
+    space,
+    repoName: repository,
+  });
+
+  await UserModel.findByIdAndUpdateProject(userId, newProject._id);
+
+  res.json({
+    result: "ok",
+    projectId: newProject._id,
+  });
+
+  const project = new ProjectService();
+
+  await project.deployProject({
+    ...buildOption,
+    userId,
+    githubAccessToken,
+  });
+
+  const {
+    // subdomain,
+    // repoName,
+    // repoOwner,
+    // repoCloneUrl,
+    // nodeVersion,
+    // installCommand,
+    // buildCommand,
+    // envList,
+    // buildType,
+    // repoId,
+    repoUpdatedAt,
+    deployedUrl,
+    buildingLog,
+    instanceId,
+    lastCommitMessage,
+    webhookId,
+  } = project;
+
+  await ProjectModel.findByIdAndUpdate(newProject._id, {
+    instanceId,
+    deployedUrl,
+    lastCommitMessage,
+    // add lastCommitHash,
+    // add publicIpAddress,
+    webhookId,
+  });
+
+  await DeploymentModel.findByIdAndUpdate(newProject._id, {
+    buildingLog,
+    repoUpdatedAt,
+    deployedStatus: "test...",
+    lastCommitMessage: "test...",
+    lastCommitHash: "test...",
+  });
+
+  return;
+});
+
+export const getUserProjects = catchAsync(async (req, res, next) => {
+  const { user_id } = req.params;
+
+  if (!user_id) {
+    return next(createError(401, "Cannot find environment data 'user_id'"));
+  }
+
+  const userProjects = await UserModel.findByIdAndGetProjects(user_id);
+
+  const filteredUserProjects = userProjects?.map(project => {
+    const {
+      _id,
+      space,
+      repoName,
+      repoCloneUrl,
+      repoUpdatedAt,
+      projectName,
+      nodeVersion,
+      installCommand,
+      buildCommand,
+      buildType,
+      envList,
+      instanceId,
+      deployedUrl,
+      lastCommitMessage,
+      lastCommitHash,
+      deployments,
+    } = project;
+
+    const filteredProjectData = {
+      repoName,
+      space,
+      repoCloneUrl,
+      repoUpdatedAt,
+      projectName,
+      nodeVersion,
+      installCommand,
+      buildCommand,
+      envList,
+      buildType,
+      deployedUrl,
+      instanceId,
+      projectId: _id,
+      lastCommitMessage,
+      lastCommitHash,
+      deployments,
+    };
+
+    return filteredProjectData;
+  });
+
+  return res.json({
+    result: "ok",
+    data: filteredUserProjects,
+  });
+});
+
+export const updateProject = catchAsync(async (req, res, next) => {
+  const { action, pull_request, repository } = req.body;
+
+  if (action !== "closed" || !pull_request.merged) {
+    return next(
+      createError(
+        401,
+        "Received abnormal PR data or PR that has not yet been merged.",
+      ),
+    );
+  }
+
+  const githubAccessToken = Config.USER_CREDENTIAL_TOKEN;
+  const githubClient = new GithubClient(githubAccessToken as string);
+  const project = new ProjectService();
+
+  const repoOwner = repository.owner.login;
+  const repoName = repository.name;
+  const headRef = pull_request.head.ref;
+
+  const { commit } = await githubClient.getHeadCommitMessage(
+    repoOwner,
+    repoName,
+    headRef,
+  );
+
+  const redeployOptions = {
+    repoCloneUrl: repository.clone_url,
+    lastCommitMessage: commit.message,
+    repoName,
+  };
+  await project.redeployProject(redeployOptions);
+
+  return res.json({
+    result: "ok",
+  });
+});
+
+export const deleteProject = catchAsync(async (req, res, next) => {
+  const { githubAccessToken } = req.query;
+  const { projectId } = req.params;
+
+  if (!githubAccessToken || !projectId) {
+    return next(
+      createError(
+        400,
+        "Cannot find environment data 'githubAccessToken', and 'projectName'",
+      ),
+    );
+  }
+
+  const deletedProject = await ProjectModel.findByIdAndDelete(projectId);
+
+  if (!deletedProject) {
+    return next(createError(500));
+  }
+
+  const project = new ProjectService();
+
+  await project.deleteProject({
+    repoId: deletedProject?._id,
+    instanceId: deletedProject?.instanceId,
+    projectName: deletedProject?.projectName,
+    publicIpAddress: deletedProject?.publicIpAddress,
+  });
+
+  return res.json({
+    result: "ok",
+  });
+});

--- a/src/models/Deployment.ts
+++ b/src/models/Deployment.ts
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+import joi from "joi";
+import joigoose from "joigoose";
+import { Deployment } from "@src/types";
+
+const Joigoose = joigoose(mongoose);
+
+const joiDeploymentSchema = joi.object({
+  buildingLog: joi.array().items(joi.string()),
+  deployStatus: joi.string(),
+  lastCommitHash: joi.string(),
+  lastCommitMessage: joi.string(),
+  repoUpdatedAt: joi.string(),
+});
+
+const deploymentSchema = new mongoose.Schema(
+  Joigoose.convert(joiDeploymentSchema),
+  {
+    versionKey: false,
+  },
+);
+const Deployment = mongoose.model<Deployment>("Deployment", deploymentSchema);
+
+export default Deployment;

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+import joi from "joi";
+import joigoose from "joigoose";
+import Deployment from "./Deployment";
+
+import { Project } from "@src/types";
+
+const Joigoose = joigoose(mongoose);
+
+const joiProjectSchema = joi.object({
+  space: joi.string(),
+  repoName: joi.string(),
+  repoCloneUrl: joi.string(),
+  repoUpdatedAt: joi.string(),
+  projectName: joi.string(),
+  nodeVersion: joi.string(),
+  installCommand: joi.string().allow("").default("npm install"),
+  buildCommand: joi.string().allow("").default("npm run build"),
+  buildType: joi.string().allow("").default("Next.js"),
+  envList: joi.array().items(
+    joi.object({
+      key: joi.string(),
+      value: joi.string(),
+    }),
+  ),
+  instanceId: joi.string().allow(""),
+  deployedUrl: joi.string().allow(""),
+  deployments: joi.array().items(
+    joi.string().meta({
+      _mongoose: { type: "ObjectId", ref: "Deployment" },
+    }),
+  ),
+  lastCommitMessage: joi.string(),
+  lastCommitHash: joi.string(),
+  webhookId: joi.string(),
+  publicIpAddress: joi.string(),
+});
+
+const projectSchema = new mongoose.Schema(Joigoose.convert(joiProjectSchema), {
+  versionKey: false,
+});
+
+projectSchema.pre<Project>("save", async function (next) {
+  const deployment = await Deployment.create({
+    deployStatus: "pending",
+  });
+
+  if (!deployment) {
+    const err = new Error("Creation failed.");
+    return next(err);
+  }
+
+  this?.deployments?.push(deployment._id);
+
+  return next();
+});
+
+const Project = mongoose.model<Project>("Project", projectSchema);
+
+export default Project;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -2,14 +2,14 @@ import mongoose from "mongoose";
 import joi from "joi";
 import joigoose from "joigoose";
 
-import { User } from "@src/types";
+import { Project, User } from "@src/types";
 
-const joiUserSchema = joi.object({
+const joiNewUserSchema = joi.object({
   username: joi.string().required(),
   userGithubUri: joi.string().required(),
   userImage: joi.string(),
   githubAccessToken: joi.string(),
-  myRepos: joi.array().items(
+  projects: joi.array().items(
     joi.string().meta({
       _mongoose: { type: "ObjectId", ref: "Repo" },
     }),
@@ -17,9 +17,18 @@ const joiUserSchema = joi.object({
 });
 
 const Joigoose = joigoose(mongoose);
-const userSchema = new mongoose.Schema(Joigoose.convert(joiUserSchema), {
+const newUserSchema = new mongoose.Schema(Joigoose.convert(joiNewUserSchema), {
   versionKey: false,
 });
-const User = mongoose.model<User>("User", userSchema);
 
-export default User;
+newUserSchema.pre<Project>("remove", function (next) {
+  NewUser.updateMany(
+    { projects: this._id },
+    { $pull: { projects: this._id } },
+    next,
+  );
+});
+
+const NewUser = mongoose.model<User>("NewUser", newUserSchema);
+
+export default NewUser;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import loginRouter from "@src/routes/login";
 import deployRouter from "@src/routes/deploy";
+import projectsRouter from "@src/routes/projects";
 import usersRouter from "@src/routes/users";
 import reposRouter from "@src/routes/repos";
 
@@ -11,6 +12,7 @@ const routes = (): Router => {
   loginRouter(router);
   usersRouter(router);
   deployRouter(router);
+  projectsRouter(router);
   reposRouter(router);
 
   return router;

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,7 +1,8 @@
+import { Router } from "express";
+
 import * as AuthController from "@src/controllers/auth";
 import verifyGithubCode from "@src/middlewares/verifyGithubCode";
 
-import { Router } from "express";
 
 const route = Router();
 

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+
+import Joi from "joi";
+
+import {
+  createProject,
+  getUserProjects,
+  updateProject,
+  deleteProject,
+} from "@src/controllers/project";
+
+import verifyToken from "@src/middlewares/verifyToken";
+import validateSchema from "@src/middlewares/validateSchema";
+
+const route = Router();
+
+const projectsRouter = (app: Router) => {
+  app.use("/projects", verifyToken, route);
+
+  route.post("/", createProject);
+
+  route.post(
+    "/:projectId",
+    validateSchema(
+      Joi.object({
+        projectId: Joi.string().regex(/^[a-f\d]{24}$/i),
+      }),
+      "params[projectId]",
+    ),
+    updateProject,
+  );
+
+  route.get(
+    "/:projectId",
+    validateSchema(
+      Joi.object({
+        projectId: Joi.string().regex(/^[a-f\d]{24}$/i),
+      }),
+      "params[projectId]",
+    ),
+    getUserProjects,
+  );
+
+  route.delete(
+    "/:projectId",
+    validateSchema(
+      Joi.object({
+        projectId: Joi.string().regex(/^[a-f\d]{24}$/i),
+      }),
+      "params[projectId]",
+    ),
+    deleteProject,
+  );
+};
+
+export default projectsRouter;

--- a/src/services/DBService/deployment.ts
+++ b/src/services/DBService/deployment.ts
@@ -1,0 +1,37 @@
+import Deployment from "@src/models/Deployment";
+import { Deployment as DeploymentType } from "@src/types";
+
+class DeploymentModel {
+  static async create() {
+    const newDeployment = await Deployment.create({
+      deployStatus: "pending",
+    });
+
+    return newDeployment;
+  }
+
+  static async findByIdAndUpdate(
+    id: DeploymentType["_id"] | string,
+    data: DeploymentType,
+  ) {
+    const {
+      buildingLog,
+      deployedStatus,
+      lastCommitMessage,
+      lastCommitHash,
+      repoUpdatedAt,
+    } = data;
+
+    const updatedDeployment = await Deployment.findByIdAndUpdate(id, {
+      buildingLog,
+      deployedStatus,
+      lastCommitMessage,
+      lastCommitHash,
+      repoUpdatedAt,
+    });
+
+    return updatedDeployment;
+  }
+}
+
+export default DeploymentModel;

--- a/src/services/DBService/deployment.ts
+++ b/src/services/DBService/deployment.ts
@@ -1,5 +1,5 @@
 import Deployment from "@src/models/Deployment";
-import { Deployment as DeploymentType } from "@src/types";
+import { Deployment as DeploymentType, IdParameter } from "@src/types/db";
 
 class DeploymentModel {
   static async create() {
@@ -10,10 +10,7 @@ class DeploymentModel {
     return newDeployment;
   }
 
-  static async findByIdAndUpdate(
-    id: DeploymentType["_id"] | string,
-    data: DeploymentType,
-  ) {
+  static async findByIdAndUpdate(id: IdParameter, data: DeploymentType) {
     const {
       buildingLog,
       deployedStatus,

--- a/src/services/DBService/project.ts
+++ b/src/services/DBService/project.ts
@@ -1,0 +1,116 @@
+import Project from "@src/models/Project";
+import Deployment from "@src/models/Deployment";
+import {
+  BuildOptions,
+  Project as ProjectType,
+  MongoDbId,
+} from "@src/types/index";
+
+type Id = MongoDbId | string;
+
+type Property = {
+  repoName?: string;
+  repoCloneUrl?: string;
+  repoUpdatedAt?: string;
+  projectName?: string;
+  nodeVersion?: string;
+  installCommand?: string;
+  buildCommand?: string;
+  buildType?: string;
+  envList?: string;
+  space?: string;
+  instanceId?: string;
+  deployedUrl?: string;
+  lastCommitMessage?: string;
+  lastCommitHash?: string;
+  webhookId?: string;
+  deployments?: ProjectType["_id"][];
+  publicIpAddress?: string;
+};
+
+class ProjectModel {
+  static async create(data: BuildOptions) {
+    const {
+      userId,
+      space,
+      repoName,
+      repoCloneUrl,
+      projectName,
+      nodeVersion,
+      installCommand,
+      buildCommand,
+      envList,
+      buildType,
+    } = data;
+
+    if (
+      !userId ||
+      !space ||
+      !repoName ||
+      !repoCloneUrl ||
+      !projectName ||
+      !nodeVersion ||
+      !installCommand ||
+      !buildCommand ||
+      !buildType ||
+      !envList
+    ) {
+      throw Error("Cannot find environment data before saving project.");
+    }
+
+    const newProject = await Project.create({
+      repoName,
+      repoCloneUrl,
+      projectName,
+      nodeVersion,
+      installCommand,
+      buildCommand,
+      buildType,
+      envList,
+    });
+
+    return newProject;
+  }
+
+  static async findByIdAndUpdate(id: Id, data: Property) {
+    const updatedProject = await Project.updateOne(
+      { _id: id },
+      { $set: { ...data } },
+    );
+
+    return updatedProject;
+  }
+
+  static async findByIdAndUpdateDeployment(projectId: Id, deploymentId: Id) {
+    if (!projectId || !deploymentId) {
+      throw Error("Expected 2 arguments, but insufficient arguments.");
+    }
+
+    const updatedProject = await Project.updateOne(
+      { _id: projectId },
+      { $push: { deployments: deploymentId } },
+    );
+
+    return updatedProject;
+  }
+
+  static async findByIdAndDelete(id: Id) {
+    if (!id) {
+      throw Error("Expected 1 arguments, but insufficient arguments.");
+    }
+
+    const deletedProject = await Project.findByIdAndDelete(id);
+
+    if (!deletedProject) return;
+
+    await Deployment.deleteMany({
+      _id: {
+        $in: deletedProject.deployments,
+      },
+    });
+
+    return deletedProject;
+  }
+}
+
+export default ProjectModel;

--- a/src/services/DBService/project.ts
+++ b/src/services/DBService/project.ts
@@ -1,37 +1,11 @@
 import Project from "@src/models/Project";
 import Deployment from "@src/models/Deployment";
-import {
-  BuildOptions,
-  Project as ProjectType,
-  MongoDbId,
-} from "@src/types/index";
-
-type Id = MongoDbId | string;
-
-type Property = {
-  repoName?: string;
-  repoCloneUrl?: string;
-  repoUpdatedAt?: string;
-  projectName?: string;
-  nodeVersion?: string;
-  installCommand?: string;
-  buildCommand?: string;
-  buildType?: string;
-  envList?: string;
-  space?: string;
-  instanceId?: string;
-  deployedUrl?: string;
-  lastCommitMessage?: string;
-  lastCommitHash?: string;
-  webhookId?: string;
-  deployments?: ProjectType["_id"][];
-  publicIpAddress?: string;
-};
+import { BuildOptions } from "@src/types";
+import { IdParameter, ProjectProperty } from "@src/types/db";
 
 class ProjectModel {
   static async create(data: BuildOptions) {
     const {
-      userId,
       space,
       repoName,
       repoCloneUrl,
@@ -39,12 +13,11 @@ class ProjectModel {
       nodeVersion,
       installCommand,
       buildCommand,
-      envList,
       buildType,
+      envList,
     } = data;
 
     if (
-      !userId ||
       !space ||
       !repoName ||
       !repoCloneUrl ||
@@ -59,6 +32,7 @@ class ProjectModel {
     }
 
     const newProject = await Project.create({
+      space,
       repoName,
       repoCloneUrl,
       projectName,
@@ -72,7 +46,7 @@ class ProjectModel {
     return newProject;
   }
 
-  static async findByIdAndUpdate(id: Id, data: Property) {
+  static async findByIdAndUpdate(id: IdParameter, data: ProjectProperty) {
     const updatedProject = await Project.updateOne(
       { _id: id },
       { $set: { ...data } },
@@ -81,7 +55,10 @@ class ProjectModel {
     return updatedProject;
   }
 
-  static async findByIdAndUpdateDeployment(projectId: Id, deploymentId: Id) {
+  static async findByIdAndUpdateDeployment(
+    projectId: IdParameter,
+    deploymentId: IdParameter,
+  ) {
     if (!projectId || !deploymentId) {
       throw Error("Expected 2 arguments, but insufficient arguments.");
     }
@@ -94,7 +71,7 @@ class ProjectModel {
     return updatedProject;
   }
 
-  static async findByIdAndDelete(id: Id) {
+  static async findByIdAndDelete(id: IdParameter) {
     if (!id) {
       throw Error("Expected 1 arguments, but insufficient arguments.");
     }

--- a/src/services/DBService/user.ts
+++ b/src/services/DBService/user.ts
@@ -1,0 +1,79 @@
+import User from "@src/models/User";
+import { Project, User as UserType, MongoDbId } from "@src/types";
+
+type Id = MongoDbId | string;
+
+type Property = {
+  username?: string;
+  userGithubUri?: string;
+  userImage?: string;
+  githubAccessToken?: string;
+  projects?: MongoDbId[];
+};
+
+class UserModel {
+  static async create(data: UserType) {
+    const { username, userGithubUri, userImage, githubAccessToken } = data;
+
+    const newUser = await User.create({
+      username,
+      userGithubUri,
+      userImage,
+      githubAccessToken,
+    });
+
+    return newUser;
+  }
+
+  static async findById(id: Id) {
+    const user = await User.findOne({ _id: id });
+
+    return user;
+  }
+
+  static async findByProperty(property: Property) {
+    if (!property) {
+      throw Error("Expected 1 arguments, but insufficient arguments.");
+    }
+
+    const user = await User.findOne({ property });
+
+    return user;
+  }
+
+  static async findByIdAndGetProjects(id: Id) {
+    const user = await User.findOne({ _id: id })
+      .populate<{ projects: Project[] }>("projects")
+      .lean();
+
+    const userProjects = user?.projects || [];
+
+    return userProjects;
+  }
+
+  static async findByIdAndUpdateProject(
+    userId: string,
+    projectId: UserType["_id"],
+  ) {
+    const user = await User.updateOne(
+      { _id: userId },
+      { $push: { projects: projectId } },
+    );
+
+    return user;
+  }
+
+  static async findByIdAndDeleteProject(
+    userId: string | UserType["_id"],
+    projectId: string | UserType["_id"],
+  ) {
+    const user = await User.updateOne(
+      { _id: userId },
+      { $pull: { myRepos: projectId } },
+    );
+
+    return user;
+  }
+}
+
+export default UserModel;

--- a/src/services/DBService/user.ts
+++ b/src/services/DBService/user.ts
@@ -1,15 +1,11 @@
 import User from "@src/models/User";
-import { Project, User as UserType, MongoDbId } from "@src/types";
-
-type Id = MongoDbId | string;
-
-type Property = {
-  username?: string;
-  userGithubUri?: string;
-  userImage?: string;
-  githubAccessToken?: string;
-  projects?: MongoDbId[];
-};
+import {
+  User as UserType,
+  Project,
+  IdParameter,
+  UserProperty,
+} from "@src/types/db";
+import { LeanDocument } from "mongoose";
 
 class UserModel {
   static async create(data: UserType) {
@@ -25,13 +21,13 @@ class UserModel {
     return newUser;
   }
 
-  static async findById(id: Id) {
+  static async findById(id: IdParameter) {
     const user = await User.findOne({ _id: id });
 
     return user;
   }
 
-  static async findByProperty(property: Property) {
+  static async findByProperty(property: UserProperty) {
     if (!property) {
       throw Error("Expected 1 arguments, but insufficient arguments.");
     }
@@ -41,19 +37,21 @@ class UserModel {
     return user;
   }
 
-  static async findByIdAndGetProjects(id: Id) {
-    const user = await User.findOne({ _id: id })
+  static async findByIdAndGetProjects(id: IdParameter) {
+    const user:
+      | {
+          projects: Project[];
+        }
+      | undefined = await User.findOne({ _id: id })
       .populate<{ projects: Project[] }>("projects")
       .lean();
 
-    const userProjects = user?.projects || [];
-
-    return userProjects;
+    return user?.projects || [];
   }
 
   static async findByIdAndUpdateProject(
-    userId: string,
-    projectId: UserType["_id"],
+    userId: IdParameter,
+    projectId: IdParameter,
   ) {
     const user = await User.updateOne(
       { _id: userId },
@@ -64,8 +62,8 @@ class UserModel {
   }
 
   static async findByIdAndDeleteProject(
-    userId: string | UserType["_id"],
-    projectId: string | UserType["_id"],
+    userId: IdParameter,
+    projectId: IdParameter,
   ) {
     const user = await User.updateOne(
       { _id: userId },

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,0 +1,70 @@
+import { Types } from "mongoose";
+
+export interface User {
+  _id?: Types.ObjectId;
+  username: string;
+  userGithubUri: string;
+  userImage?: string;
+  githubAccessToken?: string;
+  projects?: Types.ObjectId[];
+}
+
+export type Project = {
+  _id?: Types.ObjectId;
+  space?: string;
+  repoName: string;
+  repoCloneUrl: string;
+  repoUpdatedAt: string;
+  projectName: string;
+  nodeVersion: string;
+  installCommand: string;
+  buildCommand: string;
+  buildType: string;
+  envList: string;
+  deployments: Types.ObjectId[];
+  instanceId?: string;
+  deployedUrl?: string;
+  lastCommitMessage?: string;
+  lastCommitHash?: string;
+  webhookId?: string;
+  publicIpAddress?: string;
+};
+
+export type Deployment = {
+  _id?: Types.ObjectId;
+  buildingLog: (string | undefined)[] | undefined;
+  deployedStatus: string;
+  lastCommitMessage: string;
+  lastCommitHash: string;
+  repoUpdatedAt?: string;
+};
+
+export type IdParameter = Types.ObjectId | string;
+
+export type ProjectProperty = {
+  space?: string;
+  repoName?: string;
+  repoCloneUrl?: string;
+  repoUpdatedAt?: string;
+  projectName?: string;
+  nodeVersion?: string;
+  installCommand?: string;
+  buildCommand?: string;
+  buildType?: string;
+  envList?: string;
+  instanceId?: string;
+  deployedUrl?: string;
+  lastCommitMessage?: string;
+  lastCommitHash?: string;
+  webhookId?: string;
+  deployments?: Types.ObjectId[];
+  publicIpAddress?: string;
+};
+
+export type UserProperty = {
+  username?: string;
+  userGithubUri?: string;
+  userImage?: string;
+  githubAccessToken?: string;
+  projects?: Types.ObjectId[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,40 +5,6 @@ export interface Env {
   value: string;
 }
 
-export interface User {
-  _id: Types.ObjectId;
-  username: string;
-  userGithubUri: string;
-  userImage?: string;
-  githubAccessToken?: string;
-  myRepos?: Types.ObjectId[];
-}
-
-export interface Project {
-  _id: Types.ObjectId;
-  repoName: string;
-  repoOwner: string;
-  repoCloneUrl: string;
-  repoUpdatedAt: string;
-  nodeVersion: string;
-  recordId?: string;
-  webhookId?: string;
-  subdomain?: string;
-  userId?: string;
-  buildType: string;
-}
-
-export interface Deployment {
-  installCommand: string;
-  buildCommand: string;
-  envList?: Env[];
-  instanceId: string;
-  deployedUrl?: string;
-  buildingLog?: (string | undefined)[] | undefined;
-  lastCommitMessage?: string;
-  publicIpAddress?: string;
-}
-
 export type Next = Function;
 
 export type ServiceHandler<T> = (
@@ -55,8 +21,84 @@ export enum LogType {
   Error,
 }
 
+export type MongoDbId = Types.ObjectId;
+
+export interface User {
+  _id?: MongoDbId;
+  username: string;
+  userGithubUri: string;
+  userImage?: string;
+  githubAccessToken?: string;
+  projects?: MongoDbId[];
+}
+
+export type Project = {
+  _id?: MongoDbId;
+  space?: string;
+  repoName: string;
+  repoCloneUrl: string;
+  repoUpdatedAt: string;
+  projectName: string;
+  nodeVersion: string;
+  installCommand: string;
+  buildCommand: string;
+  buildType: string;
+  envList: string;
+  deployments: MongoDbId[];
+  instanceId?: string;
+  deployedUrl?: string;
+  lastCommitMessage?: string;
+  lastCommitHash?: string;
+  webhookId?: string;
+  publicIpAddress?: string;
+};
+
+export type Deployment = {
+  _id?: MongoDbId;
+  buildingLog: (string | undefined)[] | undefined;
+  deployedStatus: string;
+  lastCommitMessage: string;
+  lastCommitHash: string;
+  repoUpdatedAt?: string;
+};
+
+export type BuildOptions = {
+  userId: string;
+  space: string;
+  repoName: string;
+  repoCloneUrl: string;
+  repoUpdatedAt?: string;
+  projectName?: string;
+  nodeVersion: string;
+  installCommand: string;
+  buildCommand: string;
+  envList: Env[];
+  buildType: string;
+  githubAccessToken?: string;
+};
+
 // TEMP
-export type Repo = Project & Deployment;
+export type Repo = {
+  _id: MongoDbId;
+  repoName: string;
+  repoOwner: string;
+  repoCloneUrl: string;
+  repoUpdatedAt: string;
+  nodeVersion: string;
+  recordId?: string;
+  webhookId?: string;
+  subdomain?: string;
+  userId?: string;
+  buildType: string;
+  installCommand: string;
+  buildCommand: string;
+  envList?: Env[];
+  instanceId: string;
+  deployedUrl?: string;
+  buildingLog?: (string | undefined)[] | undefined;
+  lastCommitMessage?: string;
+  publicIpAddress?: string;
+};
 
 export type RedeployOptions = {
   repoCloneUrl: string;
@@ -66,23 +108,10 @@ export type RedeployOptions = {
 
 export type ProjectDeleteOptions = {
   instanceId?: string;
-  subdomain?: string;
+  projectName?: string;
   publicIpAddress?: string;
   userId?: string;
-  repoId?: Types.ObjectId;
-};
-
-export type BuildOptions = {
-  repoName: string;
-  repoCloneUrl: string;
-  repoUpdatedAt: string;
-  nodeVersion: string;
-  installCommand: string;
-  buildCommand: string;
-  envList: Env[];
-  buildType: string;
-  githubAccessToken: string;
-  userId: string;
+  repoId?: MongoDbId;
 };
 
 // export interface ClientOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,47 +21,6 @@ export enum LogType {
   Error,
 }
 
-export type MongoDbId = Types.ObjectId;
-
-export interface User {
-  _id?: MongoDbId;
-  username: string;
-  userGithubUri: string;
-  userImage?: string;
-  githubAccessToken?: string;
-  projects?: MongoDbId[];
-}
-
-export type Project = {
-  _id?: MongoDbId;
-  space?: string;
-  repoName: string;
-  repoCloneUrl: string;
-  repoUpdatedAt: string;
-  projectName: string;
-  nodeVersion: string;
-  installCommand: string;
-  buildCommand: string;
-  buildType: string;
-  envList: string;
-  deployments: MongoDbId[];
-  instanceId?: string;
-  deployedUrl?: string;
-  lastCommitMessage?: string;
-  lastCommitHash?: string;
-  webhookId?: string;
-  publicIpAddress?: string;
-};
-
-export type Deployment = {
-  _id?: MongoDbId;
-  buildingLog: (string | undefined)[] | undefined;
-  deployedStatus: string;
-  lastCommitMessage: string;
-  lastCommitHash: string;
-  repoUpdatedAt?: string;
-};
-
 export type BuildOptions = {
   userId: string;
   space: string;
@@ -79,7 +38,7 @@ export type BuildOptions = {
 
 // TEMP
 export type Repo = {
-  _id: MongoDbId;
+  _id: Types.ObjectId;
   repoName: string;
   repoOwner: string;
   repoCloneUrl: string;
@@ -111,7 +70,7 @@ export type ProjectDeleteOptions = {
   projectName?: string;
   publicIpAddress?: string;
   userId?: string;
-  repoId?: MongoDbId;
+  repoId?: Types.ObjectId;
 };
 
 // export interface ClientOptions {


### PR DESCRIPTION
## Task
- add projects route
- add Deployment, Project model

## Description

### projects route 추가, controller 추가
- projects route를 추가하였습니다. (deploy route를 대신할 라우트입니다.)
- deploy controller를 복사해서 project controller로 만든 후 업데이트 하였습니다.
  - projects route에 생성 요청을 보내면 바로 db를 생성한 후 response를 보내고 배포작업이 수행되도록 해놓았습니다.

### 스키마 수정, 추가
- User 스키마를 수정하였습니다.
  - `myRepos`에서 `projects`로 변경하였습니다.
  - mongoose middleware를 이용해 project가 삭제되면 User db의 projects안에서도 삭제되게 해두었습니다. 
- Project 스키마를 추가하였습니다. (Repo 스키마를 대신 할 스키마입니다)
  - repoOwner -> space, projectName추가, deployments추가, lastCommitHash추가, publicIpAddress추가, buildingLog를 삭제하였습니다.
  - mongoose middleware를 이용해 Project db를 추가하면 자동으로 Deployment가 생성되고, deployments 속성안에 id값이 추가되도록 해주었습니다.
- Deployment 스키마를 추가하였습니다.

### DB service 추가
- model을 수정하는 로직을 모아놓기 위해 DB service를 추가하였습니다.
- class static을 이용해 구현하였습니다.

- db property관련해서 용어들이 아직 수정되지 않은 부분이 많습니다. 양해 부탁드립니다. 

## Key Points

## Checklist - reusable and pure functions

- [X] Is everything function needs specified as parameters?
  - Is function reusable (cacheable) and pure? (If it's possible)
  - No random values
  - No current date/time
  - No global state (DOM, files, db, etc)
  - No mutation of parameters

## Anything to add

- [기타 논의 사항]
